### PR TITLE
debezium/dbz#1631 Heartbeat support using CockroachDB resolved timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ For CockroachDB Cloud (Serverless or Dedicated), use `verify-full` SSL mode:
 
 CockroachDB Cloud clusters use publicly trusted certificates, so no `sslrootcert` is needed.
 
+## Heartbeat Support
+
+CockroachDB changefeed [resolved timestamps](https://www.cockroachlabs.com/docs/stable/changefeed-messages#resolved-messages) serve as natural heartbeats. When the connector receives a resolved timestamp it updates the stored offset cursor and dispatches a Debezium heartbeat event, ensuring offsets advance even during idle periods with no data changes.
+
+To emit heartbeat records to the `__debezium-heartbeat.<topic.prefix>` Kafka topic, set:
+
+```json
+{
+  "heartbeat.interval.ms": "10000"
+}
+```
+
+The `cockroachdb.changefeed.resolved.interval` property (default `10s`) controls how frequently CockroachDB emits resolved timestamps.
+
 ## Testing
 
 Run all unit tests:
@@ -254,7 +268,6 @@ COCKROACHDB_VERSION=v25.2.3 docker-compose -f src/test/scripts/docker-compose.ym
 - **Single changefeed job**: The connector creates a single multi-table changefeed (`CREATE CHANGEFEED FOR table1, table2, ...`) and consumes all per-table Kafka topics concurrently in a single KafkaConsumer. This is the [recommended approach](https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations) to stay within CockroachDB's ~80 changefeed job limit per cluster.
 - **No schema change detection**: DDL changes (ALTER TABLE) are not automatically detected. Restart the connector after schema changes.
 - **No incremental snapshots**: Signal-based incremental snapshots are not yet supported. Initial snapshots are supported via CockroachDB's native `initial_scan` changefeed option (see Snapshot Configuration above).
-- **No heartbeat support**: Heartbeat events are not emitted.
 - **Kafka-only sink**: Only Kafka sinks are supported. Webhook, Pub/Sub, and cloud storage sinks are planned.
 
 ## Troubleshooting

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -8,6 +8,7 @@ package io.debezium.connector.cockroachdb;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -89,6 +90,12 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      */
     private volatile boolean initialScanInProgress = false;
 
+    /**
+     * Partition instance from {@link #execute}, stored for heartbeat dispatch
+     * in the consumer loop and resolved-timestamp handler.
+     */
+    private CockroachDBPartition currentPartition;
+
     public CockroachDBStreamingChangeEventSource(
                                                  CockroachDBConnectorConfig config,
                                                  EventDispatcher<CockroachDBPartition, TableId> dispatcher,
@@ -111,9 +118,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         Objects.requireNonNull(schema, "schema must not be null");
         Objects.requireNonNull(clock, "clock must not be null");
 
-        LOGGER.info("Starting CockroachDB streaming from cursor '{}', sink type '{}'",
-                offsetContext.getCursor(), config.getChangefeedSinkType());
+        LOGGER.info("Starting CockroachDB streaming from cursor '{}', sink type '{}', heartbeat={}ms",
+                offsetContext.getCursor(), config.getChangefeedSinkType(),
+                config.getHeartbeatInterval().toMillis());
         running.set(true);
+        this.currentPartition = partition;
 
         try (CockroachDBConnection connection = new CockroachDBConnection(config)) {
             connection.connect();
@@ -291,6 +300,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     if (emptyPollCount % 100 == 0) {
                         LOGGER.debug("No events received for {} consecutive polls", emptyPollCount);
                     }
+                    // Emit heartbeat during idle periods to advance offsets
+                    dispatcher.dispatchHeartbeatEvent(currentPartition, offsetContext);
                 }
                 else {
                     emptyPollCount = 0;
@@ -377,7 +388,14 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     initialScanInProgress = false;
                     LOGGER.info("Initial scan completed (first resolved timestamp received: {})", resolvedTs);
                 }
-                LOGGER.debug("Received resolved timestamp: {}", resolvedTs);
+
+                // Update offset with the resolved timestamp so offsets advance
+                offsetContext.setCursor(resolvedTs);
+                offsetContext.setTimestamp(parseResolvedTimestamp(resolvedTs));
+                LOGGER.debug("Received resolved timestamp: {}, offset advanced", resolvedTs);
+
+                // Dispatch heartbeat to commit the advanced offset
+                dispatcher.dispatchHeartbeatEvent(currentPartition, offsetContext);
                 return;
             }
 
@@ -574,6 +592,31 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             return "";
         }
         return identifier.replaceAll("[^a-zA-Z0-9_.\\-]", "");
+    }
+
+    /**
+     * Parses a CockroachDB resolved timestamp string into an {@link Instant}.
+     *
+     * <p>CockroachDB uses HLC (Hybrid Logical Clock) timestamps in the format
+     * {@code <wall_time_nanos>.<logical_counter>}, e.g. {@code "1772695406971781718.0000000000"}.
+     * The integer part is wall-clock time in <b>nanoseconds</b> since Unix epoch;
+     * the fractional part is a logical counter (not sub-nanoseconds).</p>
+     */
+    static Instant parseResolvedTimestamp(String resolvedTs) {
+        if (resolvedTs == null || resolvedTs.isEmpty()) {
+            return Instant.EPOCH;
+        }
+        try {
+            String[] parts = resolvedTs.split("\\.");
+            long wallTimeNanos = Long.parseLong(parts[0]);
+            long seconds = wallTimeNanos / 1_000_000_000L;
+            long nanos = wallTimeNanos % 1_000_000_000L;
+            return Instant.ofEpochSecond(seconds, nanos);
+        }
+        catch (NumberFormatException | ArithmeticException e) {
+            LOGGER.warn("Unable to parse resolved timestamp '{}', using epoch", resolvedTs);
+            return Instant.EPOCH;
+        }
     }
 
     public void stop() {

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBHeartbeatTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBHeartbeatTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for heartbeat support via CockroachDB resolved timestamps.
+ * CockroachDB uses HLC (Hybrid Logical Clock) timestamps: {@code <wall_time_nanos>.<logical_counter>}.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBHeartbeatTest {
+
+    @Test
+    public void shouldParseHlcTimestamp() {
+        // 1772695406971781718 nanos = 1772695406 seconds + 971781718 nanos
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("1772695406971781718.0000000000");
+        assertThat(result.getEpochSecond()).isEqualTo(1772695406L);
+        assertThat(result.getNano()).isEqualTo(971781718);
+    }
+
+    @Test
+    public void shouldParseHlcTimestampWithLogicalCounter() {
+        // The logical counter after the dot is ignored for time purposes
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("1772695406971781718.0000000001");
+        assertThat(result.getEpochSecond()).isEqualTo(1772695406L);
+        assertThat(result.getNano()).isEqualTo(971781718);
+    }
+
+    @Test
+    public void shouldParseHlcTimestampWithZeroNanos() {
+        // Exact second boundary: 1709000000 seconds = 1709000000000000000 nanos
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("1709000000000000000.0000000000");
+        assertThat(result.getEpochSecond()).isEqualTo(1709000000L);
+        assertThat(result.getNano()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldParseTimestampWithoutLogicalCounter() {
+        // Just wall-time nanos, no dot
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("1709000000500000000");
+        assertThat(result.getEpochSecond()).isEqualTo(1709000000L);
+        assertThat(result.getNano()).isEqualTo(500000000);
+    }
+
+    @Test
+    public void shouldReturnEpochForNullTimestamp() {
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp(null);
+        assertThat(result).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    public void shouldReturnEpochForEmptyTimestamp() {
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("");
+        assertThat(result).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    public void shouldReturnEpochForMalformedTimestamp() {
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("not-a-timestamp");
+        assertThat(result).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    public void shouldParseRecentTimestampToReasonableDate() {
+        // March 2026 timestamp: wall time in nanoseconds
+        Instant result = CockroachDBStreamingChangeEventSource.parseResolvedTimestamp("1772695406971781718.0000000000");
+        assertThat(result).isAfter(Instant.parse("2026-01-01T00:00:00Z"));
+        assertThat(result).isBefore(Instant.parse("2027-01-01T00:00:00Z"));
+    }
+
+    @Test
+    public void shouldAdvanceOffsetOnResolvedTimestamp() {
+        CockroachDBConnectorConfig config = new CockroachDBConnectorConfig(
+                io.debezium.config.Configuration.create()
+                        .with("database.hostname", "localhost")
+                        .with("database.port", "26257")
+                        .with("database.user", "root")
+                        .with("database.dbname", "testdb")
+                        .with("topic.prefix", "test")
+                        .build());
+
+        CockroachDBOffsetContext offsetContext = new CockroachDBOffsetContext(config);
+        String initialCursor = offsetContext.getCursor();
+
+        String resolvedTs = "1772695406971781718.0000000000";
+        offsetContext.setCursor(resolvedTs);
+        offsetContext.setTimestamp(CockroachDBStreamingChangeEventSource.parseResolvedTimestamp(resolvedTs));
+
+        assertThat(offsetContext.getCursor()).isEqualTo(resolvedTs);
+        assertThat(offsetContext.getCursor()).isNotEqualTo(initialCursor);
+        assertThat(offsetContext.getTimestamp().getEpochSecond()).isEqualTo(1772695406L);
+    }
+
+    @Test
+    public void shouldAdvanceOffsetMultipleTimesMonotonically() {
+        CockroachDBConnectorConfig config = new CockroachDBConnectorConfig(
+                io.debezium.config.Configuration.create()
+                        .with("database.hostname", "localhost")
+                        .with("database.port", "26257")
+                        .with("database.user", "root")
+                        .with("database.dbname", "testdb")
+                        .with("topic.prefix", "test")
+                        .build());
+
+        CockroachDBOffsetContext offsetContext = new CockroachDBOffsetContext(config);
+
+        String ts1 = "1772695406971781718.0000000000";
+        String ts2 = "1772695416971781718.0000000000"; // 10 seconds later
+
+        offsetContext.setCursor(ts1);
+        offsetContext.setTimestamp(CockroachDBStreamingChangeEventSource.parseResolvedTimestamp(ts1));
+        Instant first = offsetContext.getTimestamp();
+
+        offsetContext.setCursor(ts2);
+        offsetContext.setTimestamp(CockroachDBStreamingChangeEventSource.parseResolvedTimestamp(ts2));
+        Instant second = offsetContext.getTimestamp();
+
+        assertThat(second).isAfter(first);
+        assertThat(offsetContext.getCursor()).isEqualTo(ts2);
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * Integration test for heartbeat support via CockroachDB resolved timestamps.
+ *
+ * <p>Validates that resolved timestamps advance offsets during idle periods
+ * and that the connector produces heartbeat records when configured.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBHeartbeatIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBHeartbeatIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String DATABASE_NAME = "heartbeat_testdb";
+    private static final String TABLE_NAME = "hb_events";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
+            try (Statement stmt = defaultConn.createStatement()) {
+                stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+            }
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT PRIMARY KEY, "
+                    + "data STRING NOT NULL"
+                    + ")");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldAdvanceOffsetsViaResolvedTimestamps() throws Exception {
+        // Insert one row so the changefeed has something to start with
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'initial')");
+        }
+
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "heartbeat-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "hb-test");
+        config.put("topic.prefix", "hb-test");
+        config.put("table.include.list", "public." + TABLE_NAME);
+        config.put("cockroachdb.skip.permission.check", "true");
+        config.put("cockroachdb.schema.name", "public");
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.envelope", "enriched");
+        config.put("cockroachdb.changefeed.enriched.properties", "source,schema");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        // Short resolved interval so we get frequent resolved timestamps
+        config.put("cockroachdb.changefeed.resolved.interval", "2s");
+        config.put("snapshot.mode", "initial");
+        // Enable Debezium heartbeats
+        config.put("heartbeat.interval.ms", "1000");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+
+        // Poll to get the initial data event(s) and then let idle period produce heartbeats
+        List<SourceRecord> allRecords = new ArrayList<>();
+        List<SourceRecord> heartbeatRecords = new ArrayList<>();
+        String lastOffsetCursor = null;
+        int offsetAdvanceCount = 0;
+
+        // Poll for 20 seconds: first we expect data events, then idle period with heartbeats
+        int maxAttempts = 20;
+        for (int i = 0; i < maxAttempts; i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null && !records.isEmpty()) {
+                    for (SourceRecord record : records) {
+                        String topic = record.topic();
+                        if (topic != null && topic.contains("__debezium-heartbeat")) {
+                            heartbeatRecords.add(record);
+                            LOGGER.info("  Heartbeat record: topic={}", topic);
+                        }
+                        else {
+                            allRecords.add(record);
+                            LOGGER.info("  Data record: topic={}, key={}", topic, record.key());
+                        }
+
+                        // Check if offset cursor advanced
+                        Map<String, ?> offset = record.sourceOffset();
+                        if (offset != null) {
+                            String cursor = (String) offset.get("offset.cursor");
+                            if (cursor != null && !cursor.equals(lastOffsetCursor)) {
+                                offsetAdvanceCount++;
+                                lastOffsetCursor = cursor;
+                                LOGGER.info("  Offset advanced to cursor: {}", cursor);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            catch (Exception e) {
+                LOGGER.warn("Poll attempt {} failed: {}", i + 1, e.getMessage());
+            }
+            Thread.sleep(1000);
+        }
+
+        LOGGER.info("Heartbeat IT results: {} data records, {} heartbeat records, {} offset advances",
+                allRecords.size(), heartbeatRecords.size(), offsetAdvanceCount);
+
+        // We should have received at least the initial data event
+        assertThat(allRecords).as("Should receive at least one data event").isNotEmpty();
+
+        // Offsets should have advanced more than once (initial data + resolved timestamps)
+        assertThat(offsetAdvanceCount).as("Offset should advance via resolved timestamps").isGreaterThan(1);
+
+        // The final cursor should be a resolved timestamp (numeric format like "1234567890.0000000000")
+        assertThat(lastOffsetCursor).as("Final cursor should be a resolved timestamp")
+                .matches("\\d+\\.\\d+");
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(
+                                                                                java.util.Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Wire CockroachDB changefeed resolved timestamps into Debezium's heartbeat framework to advance offsets during idle periods.

## Problem

Resolved timestamps were silently discarded, causing:
- Connector offsets to never advance during idle periods
- Monitoring tools to report the connector as stuck
- CockroachDB protected timestamp accumulation (preventing GC)

## Solution

When a resolved timestamp is received:
1. Parse the HLC timestamp (`<wall_time_nanos>.<logical_counter>`) into an `Instant`
2. Update `CockroachDBOffsetContext` cursor and timestamp
3. Dispatch a Debezium heartbeat event to commit the advanced offset

During empty Kafka polls (idle periods), dispatch heartbeat events following the PostgreSQL connector pattern.

Users can enable heartbeat records on the `__debezium-heartbeat.<topic.prefix>` topic via `heartbeat.interval.ms`.

## Changes

- **CockroachDBStreamingChangeEventSource**: Resolved timestamp -> offset advancement + heartbeat dispatch; empty poll heartbeat; HLC timestamp parser
- **README**: Heartbeat documented as feature (removed from limitations)
- **CockroachDBHeartbeatTest**: 10 unit tests (HLC parsing, edge cases, offset advancement, monotonicity)
- **CockroachDBHeartbeatIT**: Testcontainers IT verifying offset advancement via resolved timestamps

## Test Results

- 118 unit tests pass (108 existing + 10 new)
- 9 Testcontainers IT tests pass (6 connector + 2 multi-table + 1 heartbeat)
- 6 CockroachDB Cloud IT tests pass
- Format/imports clean

Resolves https://github.com/debezium/dbz/issues/1631