### PR TITLE
debezium/dbz#1711 Add JMH microbenchmarks for CockroachDB connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <version.debezium>${project.version}</version.debezium>
 
         <cockroachdb.version>v25.4.6</cockroachdb.version>
+        <version.jmh>1.37</version.jmh>
     </properties>
 
     <dependencyManagement>
@@ -247,6 +248,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- JMH for microbenchmarks (provided: compile only, not in connector distribution) -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Testcontainers for integration testing -->
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -399,6 +412,82 @@
                                         <descriptorRef>${assembly.descriptor}</descriptorRef>
                                     </descriptorRefs>
                                     <tarLongFileMode>posix</tarLongFileMode>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>benchmark</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>connect-api</artifactId>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.openjdk.jmh</groupId>
+                                    <artifactId>jmh-generator-annprocess</artifactId>
+                                    <version>${version.jmh}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-benchmarks</finalName>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                            <resource>MANIFEST.MF</resource>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>org.openjdk.jmh.Main</mainClass>
+                                        </transformer>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    </transformers>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/java/io/debezium/connector/cockroachdb/benchmark/ChangefeedJsonParsingBenchmark.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/benchmark/ChangefeedJsonParsingBenchmark.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.connector.cockroachdb.serialization.ChangefeedSchemaParser;
+
+/**
+ * JMH benchmark for CockroachDB enriched changefeed JSON parsing.
+ * Measures the throughput of the hot path: JSON deserialization + schema creation + Struct conversion.
+ *
+ * @author Virag Tripathi
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class ChangefeedJsonParsingBenchmark {
+
+    private static final int BATCH_SIZE = 100;
+
+    @Param({ "small", "medium", "large" })
+    private String payloadSize;
+
+    private ObjectMapper mapper;
+    private String[] keyJsons;
+    private String[] valueJsons;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        mapper = new ObjectMapper();
+        keyJsons = new String[BATCH_SIZE];
+        valueJsons = new String[BATCH_SIZE];
+
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            keyJsons[i] = generateKeyJson(i);
+            valueJsons[i] = generateValueJson(i, payloadSize);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public void parseEnrichedChangefeedEvent(Blackhole bh) throws Exception {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume(ChangefeedSchemaParser.parse(keyJsons[i], valueJsons[i]));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public void jsonDeserializationOnly(Blackhole bh) throws Exception {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume(mapper.readTree(valueJsons[i]));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public void resolvedTimestampParsing(Blackhole bh) throws Exception {
+        String resolved = "{\"resolved\":\"1709312345678901234.0000000000\"}";
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume(ChangefeedSchemaParser.parse(null, resolved));
+        }
+    }
+
+    private static String generateKeyJson(int id) {
+        return "[" + id + "]";
+    }
+
+    private static String generateValueJson(int id, String size) {
+        return switch (size) {
+            case "small" -> String.format(
+                    "{\"after\":{\"id\":%d,\"name\":\"item-%d\",\"price\":\"19.99\"},"
+                            + "\"op\":\"c\",\"ts_ns\":%d}",
+                    id, id, System.nanoTime());
+            case "medium" -> String.format(
+                    "{\"after\":{\"id\":%d,\"name\":\"item-%d\",\"price\":\"19.99\","
+                            + "\"description\":\"A medium-length description for benchmarking purposes that contains several words\","
+                            + "\"category\":\"electronics\",\"stock\":%d,\"active\":true,\"rating\":4.5},"
+                            + "\"before\":{\"id\":%d,\"name\":\"item-%d\",\"price\":\"14.99\","
+                            + "\"description\":\"Previous description\",\"category\":\"electronics\","
+                            + "\"stock\":%d,\"active\":true,\"rating\":4.0},"
+                            + "\"op\":\"u\",\"ts_ns\":%d,"
+                            + "\"source\":{\"version\":\"3.5.0\",\"connector\":\"cockroachdb\","
+                            + "\"name\":\"test\",\"ts_ms\":%d,\"db\":\"testdb\","
+                            + "\"schema\":\"public\",\"table_name\":\"products\"}}",
+                    id, id, id * 10, id, id, id * 10 - 5, System.nanoTime(), System.currentTimeMillis());
+            case "large" -> String.format(
+                    "{\"after\":{\"id\":%d,\"name\":\"item-%d\",\"price\":\"19.99\","
+                            + "\"description\":\"" + "x".repeat(500) + "\","
+                            + "\"category\":\"electronics\",\"stock\":%d,\"active\":true,\"rating\":4.5,"
+                            + "\"metadata\":\"{\\\"tags\\\":[\\\"sale\\\",\\\"featured\\\"],\\\"weight\\\":2.5}\","
+                            + "\"created_at\":\"2025-01-15T10:30:00Z\",\"updated_at\":\"2025-06-20T14:22:00Z\","
+                            + "\"sku\":\"SKU-%06d\",\"barcode\":\"1234567890%04d\","
+                            + "\"manufacturer\":\"Acme Corp\",\"warranty_months\":24,"
+                            + "\"dimensions\":\"{\\\"l\\\":10,\\\"w\\\":5,\\\"h\\\":3}\","
+                            + "\"color\":\"blue\",\"material\":\"aluminum\",\"country_of_origin\":\"US\"},"
+                            + "\"before\":{\"id\":%d,\"name\":\"item-%d\",\"price\":\"14.99\","
+                            + "\"description\":\"" + "y".repeat(500) + "\","
+                            + "\"category\":\"electronics\",\"stock\":%d,\"active\":true,\"rating\":4.0,"
+                            + "\"metadata\":\"{\\\"tags\\\":[\\\"sale\\\"],\\\"weight\\\":2.5}\","
+                            + "\"created_at\":\"2025-01-15T10:30:00Z\",\"updated_at\":\"2025-03-10T09:15:00Z\","
+                            + "\"sku\":\"SKU-%06d\",\"barcode\":\"1234567890%04d\","
+                            + "\"manufacturer\":\"Acme Corp\",\"warranty_months\":24,"
+                            + "\"dimensions\":\"{\\\"l\\\":10,\\\"w\\\":5,\\\"h\\\":3}\","
+                            + "\"color\":\"blue\",\"material\":\"aluminum\",\"country_of_origin\":\"US\"},"
+                            + "\"op\":\"u\",\"ts_ns\":%d,"
+                            + "\"source\":{\"version\":\"3.5.0\",\"connector\":\"cockroachdb\","
+                            + "\"name\":\"test\",\"ts_ms\":%d,\"db\":\"testdb\","
+                            + "\"schema\":\"public\",\"table_name\":\"products\"}}",
+                    id, id, id * 10, id, id, id, id, id * 10 - 5, id, id,
+                    System.nanoTime(), System.currentTimeMillis());
+            default -> throw new IllegalArgumentException("Unknown payload size: " + size);
+        };
+    }
+}

--- a/src/main/java/io/debezium/connector/cockroachdb/benchmark/OffsetContextBenchmark.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/benchmark/OffsetContextBenchmark.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.benchmark;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.cockroachdb.CockroachDBConnectorConfig;
+import io.debezium.connector.cockroachdb.CockroachDBOffsetContext;
+
+/**
+ * JMH benchmark for {@link CockroachDBOffsetContext} serialization and deserialization.
+ * Measures the cost of loading offset context from stored offsets, including
+ * incremental snapshot context restoration.
+ *
+ * @author Virag Tripathi
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class OffsetContextBenchmark {
+
+    private static final int OP_COUNT = 100;
+
+    private CockroachDBOffsetContext.Loader loader;
+    private Map<String, Object>[] storedOffsets;
+    private CockroachDBOffsetContext context;
+
+    @SuppressWarnings("unchecked")
+    @Setup(Level.Trial)
+    public void setup() {
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "defaultdb")
+                .with("topic.prefix", "bench")
+                .with("database.server.name", "bench")
+                .build();
+
+        CockroachDBConnectorConfig connectorConfig = new CockroachDBConnectorConfig(config);
+        loader = new CockroachDBOffsetContext.Loader(connectorConfig);
+        context = new CockroachDBOffsetContext(connectorConfig);
+
+        storedOffsets = new Map[OP_COUNT];
+        for (int i = 0; i < OP_COUNT; i++) {
+            Map<String, Object> offset = new HashMap<>();
+            offset.put(CockroachDBOffsetContext.CURSOR, "170931234567890" + i + ".0000000000");
+            offset.put(CockroachDBOffsetContext.TIMESTAMP, String.valueOf(System.currentTimeMillis() - i * 1000));
+            offset.put("snapshot_completed", "true");
+            storedOffsets[i] = offset;
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OP_COUNT)
+    public void loadOffsetContext(Blackhole bh) {
+        for (int i = 0; i < OP_COUNT; i++) {
+            bh.consume(loader.load(storedOffsets[i]));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OP_COUNT)
+    public void serializeOffsetContext(Blackhole bh) {
+        for (int i = 0; i < OP_COUNT; i++) {
+            context.setCursor("170931234567890" + i + ".0000000000");
+            bh.consume(context.getOffset());
+        }
+    }
+}

--- a/src/main/java/io/debezium/connector/cockroachdb/benchmark/SchemaChangeDetectionBenchmark.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/benchmark/SchemaChangeDetectionBenchmark.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.benchmark;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.connector.cockroachdb.CockroachDBStreamingChangeEventSource;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+
+/**
+ * JMH benchmark for schema change detection logic.
+ * Measures the cost of comparing incoming event fields against the registered table schema,
+ * which runs on every changefeed event during streaming.
+ *
+ * @author Virag Tripathi
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class SchemaChangeDetectionBenchmark {
+
+    private static final int OP_COUNT = 100;
+
+    @Param({ "5", "15", "30" })
+    private int columnCount;
+
+    private JsonNode[] matchingNodes;
+    private JsonNode[] mismatchNodes;
+    private Table table;
+    private Method hasSchemaChangedMethod;
+
+    private Object previousLogLevel;
+
+    @Setup(Level.Trial)
+    public void setup() throws Exception {
+        Logger logger = LoggerFactory.getLogger(CockroachDBStreamingChangeEventSource.class);
+        try {
+            Class<?> logbackLoggerClass = Class.forName("ch.qos.logback.classic.Logger");
+            Class<?> logbackLevelClass = Class.forName("ch.qos.logback.classic.Level");
+            if (logbackLoggerClass.isInstance(logger)) {
+                previousLogLevel = logbackLoggerClass.getMethod("getLevel").invoke(logger);
+                Object offLevel = logbackLevelClass.getField("OFF").get(null);
+                logbackLoggerClass.getMethod("setLevel", logbackLevelClass).invoke(logger, offLevel);
+            }
+            else {
+                previousLogLevel = null;
+            }
+        }
+        catch (ReflectiveOperationException e) {
+            previousLogLevel = null;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        hasSchemaChangedMethod = CockroachDBStreamingChangeEventSource.class
+                .getDeclaredMethod("hasSchemaChanged", JsonNode.class, Table.class);
+        hasSchemaChangedMethod.setAccessible(true);
+
+        TableId tableId = new TableId("testdb", "public", "bench_table");
+        io.debezium.relational.TableEditor editor = Table.editor()
+                .tableId(tableId);
+        for (int c = 0; c < columnCount; c++) {
+            editor.addColumn(Column.editor()
+                    .name("col_" + c)
+                    .type("STRING")
+                    .jdbcType(java.sql.Types.VARCHAR)
+                    .optional(c > 0)
+                    .create());
+        }
+        editor.setPrimaryKeyNames("col_0");
+        table = editor.create();
+
+        matchingNodes = new JsonNode[OP_COUNT];
+        mismatchNodes = new JsonNode[OP_COUNT];
+        for (int i = 0; i < OP_COUNT; i++) {
+            StringBuilder matching = new StringBuilder("{");
+            StringBuilder mismatch = new StringBuilder("{");
+            for (int c = 0; c < columnCount; c++) {
+                if (c > 0) {
+                    matching.append(",");
+                    mismatch.append(",");
+                }
+                matching.append(String.format("\"col_%d\":\"val_%d_%d\"", c, i, c));
+                mismatch.append(String.format("\"col_%d\":\"val_%d_%d\"", c, i, c));
+            }
+            matching.append("}");
+            mismatch.append(",\"new_column\":\"surprise\"}");
+            matchingNodes[i] = mapper.readTree(matching.toString());
+            mismatchNodes[i] = mapper.readTree(mismatch.toString());
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (previousLogLevel != null) {
+            try {
+                Logger logger = LoggerFactory.getLogger(CockroachDBStreamingChangeEventSource.class);
+                Class<?> logbackLoggerClass = Class.forName("ch.qos.logback.classic.Logger");
+                Class<?> logbackLevelClass = Class.forName("ch.qos.logback.classic.Level");
+                logbackLoggerClass.getMethod("setLevel", logbackLevelClass).invoke(logger, previousLogLevel);
+            }
+            catch (ReflectiveOperationException e) {
+                // best-effort restore
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OP_COUNT)
+    public void schemaUnchanged(Blackhole bh) throws Exception {
+        for (int i = 0; i < OP_COUNT; i++) {
+            bh.consume(hasSchemaChangedMethod.invoke(null, matchingNodes[i], table));
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(OP_COUNT)
+    public void schemaChanged(Blackhole bh) throws Exception {
+        for (int i = 0; i < OP_COUNT; i++) {
+            bh.consume(hasSchemaChangedMethod.invoke(null, mismatchNodes[i], table));
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/debezium/dbz/issues/1711

Add JMH microbenchmarks for CockroachDB connector hot paths: changefeed JSON parsing, offset context load/serialize, and schema change detection.

Build: `./mvnw clean package -Pbenchmark -DskipTests -DskipITs`
Run: `java -jar target/debezium-connector-cockroachdb-benchmarks.jar`

Key finding: full parsing pipeline costs 3-4x raw JSON deserialization due to per-event SchemaBuilder/Struct rebuild (tracked in debezium/dbz#1712).