### PR TITLE
debezium/dbz#1712 Optimize per-event partition allocation and add real hot-path benchmarks

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
@@ -76,12 +76,19 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
         return extractColumnValues(afterNode);
     }
 
-    /**
-     * Extracts values from a JSON node in the same order as the table's columns.
-     * Each value is converted to a Java type appropriate for the column's JDBC type.
-     */
     private Object[] extractColumnValues(JsonNode dataNode) {
-        List<Column> columns = table.columns();
+        return extractColumnValues(dataNode, table.columns());
+    }
+
+    /**
+     * Extracts values from a JSON node in the order of the supplied columns.
+     * Each value is converted to a Java type appropriate for the column's JDBC type.
+     *
+     * @param dataNode the JSON object containing field values; must not be null
+     * @param columns  the ordered list of columns to extract; must not be null
+     * @return an array of converted values in column order
+     */
+    public static Object[] extractColumnValues(JsonNode dataNode, List<Column> columns) {
         Object[] values = new Object[columns.size()];
 
         for (int i = 0; i < columns.size(); i++) {

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -455,14 +455,13 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 }
             }
 
-            CockroachDBPartition partition = new CockroachDBPartition(config.getLogicalName());
             CockroachDBChangeRecordEmitter emitter = new CockroachDBChangeRecordEmitter(
-                    partition, offsetContext, clock, config, tableObj, operation,
+                    currentPartition, offsetContext, clock, config, tableObj, operation,
                     afterNode.isMissingNode() ? null : afterNode,
                     beforeNode.isMissingNode() ? null : beforeNode);
 
             LOGGER.debug("Dispatching {} event for table {}", operation, table);
-            dispatcher.dispatchDataChangeEvent(partition, table, emitter);
+            dispatcher.dispatchDataChangeEvent(currentPartition, table, emitter);
         }
         catch (Exception e) {
             LOGGER.error("Error processing changefeed event for table {}: {}",

--- a/src/main/java/io/debezium/connector/cockroachdb/benchmark/ChangefeedJsonParsingBenchmark.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/benchmark/ChangefeedJsonParsingBenchmark.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.cockroachdb.benchmark;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -22,13 +23,19 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.debezium.connector.cockroachdb.CockroachDBChangeRecordEmitter;
 import io.debezium.connector.cockroachdb.serialization.ChangefeedSchemaParser;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
 
 /**
  * JMH benchmark for CockroachDB enriched changefeed JSON parsing.
- * Measures the throughput of the hot path: JSON deserialization + schema creation + Struct conversion.
+ * Measures both the legacy ChangefeedSchemaParser path and the real production hot path
+ * (JSON deserialization + column value extraction via CockroachDBChangeRecordEmitter).
  *
  * @author Virag Tripathi
  */
@@ -48,17 +55,46 @@ public class ChangefeedJsonParsingBenchmark {
     private ObjectMapper mapper;
     private String[] keyJsons;
     private String[] valueJsons;
+    private JsonNode[] parsedAfterNodes;
+    private Table smallTable;
+    private Table mediumTable;
+    private List<Column> columns;
 
     @Setup(Level.Trial)
-    public void setup() {
+    public void setup() throws Exception {
         mapper = new ObjectMapper();
         keyJsons = new String[BATCH_SIZE];
         valueJsons = new String[BATCH_SIZE];
+        parsedAfterNodes = new JsonNode[BATCH_SIZE];
 
         for (int i = 0; i < BATCH_SIZE; i++) {
             keyJsons[i] = generateKeyJson(i);
             valueJsons[i] = generateValueJson(i, payloadSize);
+            JsonNode root = mapper.readTree(valueJsons[i]);
+            parsedAfterNodes[i] = root.path("after");
         }
+
+        smallTable = Table.editor().tableId(new TableId("testdb", "public", "items"))
+                .addColumn(Column.editor().name("id").type("INT8").jdbcType(java.sql.Types.BIGINT).create())
+                .addColumn(Column.editor().name("name").type("STRING").jdbcType(java.sql.Types.VARCHAR).create())
+                .addColumn(Column.editor().name("price").type("DECIMAL").jdbcType(java.sql.Types.NUMERIC).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        mediumTable = Table.editor().tableId(new TableId("testdb", "public", "products"))
+                .addColumn(Column.editor().name("id").type("INT8").jdbcType(java.sql.Types.BIGINT).create())
+                .addColumn(Column.editor().name("name").type("STRING").jdbcType(java.sql.Types.VARCHAR).create())
+                .addColumn(Column.editor().name("price").type("DECIMAL").jdbcType(java.sql.Types.NUMERIC).create())
+                .addColumn(Column.editor().name("description").type("STRING").jdbcType(java.sql.Types.VARCHAR).create())
+                .addColumn(Column.editor().name("category").type("STRING").jdbcType(java.sql.Types.VARCHAR).create())
+                .addColumn(Column.editor().name("stock").type("INT8").jdbcType(java.sql.Types.BIGINT).create())
+                .addColumn(Column.editor().name("active").type("BOOL").jdbcType(java.sql.Types.BOOLEAN).create())
+                .addColumn(Column.editor().name("rating").type("FLOAT8").jdbcType(java.sql.Types.DOUBLE).create())
+                .setPrimaryKeyNames("id")
+                .create();
+
+        Table tableForBenchmark = "medium".equals(payloadSize) || "large".equals(payloadSize) ? mediumTable : smallTable;
+        columns = tableForBenchmark.columns();
     }
 
     @Benchmark
@@ -83,6 +119,33 @@ public class ChangefeedJsonParsingBenchmark {
         String resolved = "{\"resolved\":\"1709312345678901234.0000000000\"}";
         for (int i = 0; i < BATCH_SIZE; i++) {
             bh.consume(ChangefeedSchemaParser.parse(null, resolved));
+        }
+    }
+
+    /**
+     * Measures the real production hot path: JSON parse + column value extraction.
+     * This reflects the per-event cost in processChangefeedEvent(): Jackson readTree
+     * followed by column extraction via the static utility method.
+     */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public void jsonParseAndColumnExtraction(Blackhole bh) throws Exception {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            JsonNode root = mapper.readTree(valueJsons[i]);
+            JsonNode afterNode = root.path("after");
+            bh.consume(CockroachDBChangeRecordEmitter.extractColumnValues(afterNode, columns));
+        }
+    }
+
+    /**
+     * Measures only the column value extraction cost (JSON already parsed).
+     * Isolates the extractColumnValues() overhead from JSON deserialization.
+     */
+    @Benchmark
+    @OperationsPerInvocation(BATCH_SIZE)
+    public void columnExtractionOnly(Blackhole bh) {
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            bh.consume(CockroachDBChangeRecordEmitter.extractColumnValues(parsedAfterNodes[i], columns));
         }
     }
 

--- a/src/test/scripts/run-benchmarks.sh
+++ b/src/test/scripts/run-benchmarks.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Run JMH microbenchmarks for the Debezium CockroachDB connector.
+#
+# Usage:
+#   ./run-benchmarks.sh                     # all benchmarks, all payload sizes
+#   ./run-benchmarks.sh medium              # all benchmarks, medium payload only
+#   ./run-benchmarks.sh medium json         # JSON output for sharing
+#
+# Prerequisites:
+#   - Java 21+ and Maven (or use the included mvnw wrapper)
+#
+# The script builds the benchmark uber-jar (if needed) and runs JMH.
+# Results are printed to stdout; pass "json" as the second argument to
+# also write machine-readable output to benchmark-results.json.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BENCHMARK_JAR="$PROJECT_DIR/target/debezium-connector-cockroachdb-benchmarks.jar"
+
+PAYLOAD_SIZE="${1:-small,medium,large}"
+OUTPUT_FORMAT="${2:-}"
+
+# Build the benchmark jar if it doesn't exist or source is newer
+if [ ! -f "$BENCHMARK_JAR" ] || \
+   [ "$(find "$PROJECT_DIR/src" -name '*.java' -newer "$BENCHMARK_JAR" 2>/dev/null | head -1)" ]; then
+    echo "Building benchmark jar..."
+    cd "$PROJECT_DIR"
+    ./mvnw clean package -Pbenchmark -DskipTests -DskipITs -q
+    echo "Build complete."
+fi
+
+echo ""
+echo "Available benchmarks:"
+java -jar "$BENCHMARK_JAR" -l
+echo ""
+echo "Running benchmarks with payloadSize=$PAYLOAD_SIZE ..."
+echo ""
+
+JMH_ARGS=(
+    -p "payloadSize=$PAYLOAD_SIZE"
+    -f 2
+    -wi 5
+    -i 5
+    -t 1
+)
+
+if [ "$OUTPUT_FORMAT" = "json" ]; then
+    RESULTS_FILE="$PROJECT_DIR/benchmark-results.json"
+    JMH_ARGS+=(-rf json -rff "$RESULTS_FILE")
+    echo "JSON results will be written to: $RESULTS_FILE"
+    echo ""
+fi
+
+java -jar "$BENCHMARK_JAR" "${JMH_ARGS[@]}"
+
+if [ "$OUTPUT_FORMAT" = "json" ] && [ -f "$RESULTS_FILE" ]; then
+    echo ""
+    echo "Results saved to $RESULTS_FILE"
+fi


### PR DESCRIPTION
## Summary

Fixes debezium/dbz#1712 - Performance optimization for the CockroachDB connector.

### Changes

**Performance fix:**
- Eliminated per-event `CockroachDBPartition` allocation in `processChangefeedEvent()` — was creating `new CockroachDBPartition()` + `Map.of()` on every single event. Now reuses the `currentPartition` field that is already initialized once in `execute()` and used for heartbeats.

**Benchmark improvements:**
- Added `jsonParseAndColumnExtraction` benchmark measuring the **real production hot path** (JSON parsing + column value extraction via `CockroachDBChangeRecordEmitter`)
- Added `columnExtractionOnly` benchmark isolating the `extractColumnValues()` overhead
- Made `extractColumnValues()` public for benchmark access

### Benchmark Results (medium payload, 8 fields)

| Benchmark | us/op | Description |
|---|---|---|
| `columnExtractionOnly` | **0.112** | Column extraction from pre-parsed JSON |
| `jsonDeserializationOnly` | **1.353** | Raw Jackson `readTree()` |
| `jsonParseAndColumnExtraction` | **1.532** | **Real production hot path** |
| `parseEnrichedChangefeedEvent` | **4.140** | Legacy `ChangefeedSchemaParser` (not used in production) |

### Key Finding

The original benchmarks measured `ChangefeedSchemaParser.parse()` which builds `Schema`/`Struct` dynamically from JSON. However, this is **NOT the production hot path** — the actual event processing goes through `RelationalChangeRecordEmitter` → `TableSchema` (already cached by `RelationalDatabaseSchema`). The real path costs **1.53 us/op** — 2.7x faster than the legacy benchmark suggested.

### Test Results

- 149 unit tests: ✅ all pass
- 32 integration tests: ✅ all pass (4 skipped: snapshot tests)  
- 6 Cloud IT: ✅ all pass
- Checkstyle, formatter, import ordering: ✅ all pass