### PR TITLE
debezium/dbz#1922 Compile connector to Java 17 instead of Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,6 @@
     </scm>
 
     <properties>
-        <!-- JDK version is controlled by Debezium Parent, do not change! -->
-        <maven.compiler.source>${debezium.java.source}</maven.compiler.source>
-        <maven.compiler.target>${debezium.java.specific.target}</maven.compiler.target>
-        <maven.compiler.release>${debezium.java.specific.target}</maven.compiler.release>
-        <maven.compiler.testSource>${debezium.java.source}</maven.compiler.testSource>
-        <maven.compiler.testTarget>${debezium.java.specific.target}</maven.compiler.testTarget>
-        <maven.compiler.testRelease>${debezium.java.specific.target}</maven.compiler.testRelease>
-
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
 


### PR DESCRIPTION
Fixes debezium/dbz#1922

## Problem

The connector pom.xml overrode the Debezium parent compiler properties using `${debezium.java.specific.target}` (= 21, intended for Server/Operator/Outbox) instead of inheriting the parent's `maven.compiler.target` default of `${debezium.java.connector.target}` (= 17).

As a result, the connector was compiled to class file version 65 (Java 21), and Kafka Connect deployments running on Java 17 (the most common LTS for Kafka Connect today) failed to load the plugin:

```
java.lang.UnsupportedClassVersionError: io/debezium/connector/cockroachdb/CockroachDBConnector
  has been compiled by a more recent version of the Java Runtime
  (class file version 65.0), this version of the Java Runtime only recognizes
  class file versions up to 61.0
```

## Fix

Remove the property overrides so the connector inherits the parent POM's Java 17 target. This matches every other Debezium connector (vitess, cassandra, postgres, mysql, etc.) -- none of them override these properties.

## Verification

- `./mvnw clean package -DskipITs -P assembly` produces a JAR with class file version 61 (Java 17), confirmed via `javap -v`.
- All 149 unit tests pass.
- Assembly profile builds the connector distribution tarball successfully.

## Affected versions

This affects every released version of the CockroachDB connector to date (3.5.0.Final, 3.6.0.Alpha1, and 3.6.0-SNAPSHOT).