### PR TITLE
debezium/dbz#1973 debezium/dbz#1975 Fix table discovery + typed column defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Run integration tests (requires Docker for Testcontainers):
 Run against a specific CockroachDB version (default is v25.4.6):
 
 ```bash
-./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.2.3
+./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.10
 ```
 
 Run CockroachDB Cloud connectivity tests (requires a Cloud instance):
@@ -331,7 +331,7 @@ The Cloud IT is guarded by `@EnabledIfEnvironmentVariable` and will be skipped i
 For docker-compose based testing with a specific version:
 
 ```bash
-COCKROACHDB_VERSION=v25.2.3 docker-compose -f src/test/scripts/docker-compose.yml up
+COCKROACHDB_VERSION=v25.4.10 docker-compose -f src/test/scripts/docker-compose.yml up
 ```
 
 ## Known Limitations

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
 
-        <cockroachdb.version>v25.4.6</cockroachdb.version>
+        <cockroachdb.version>v25.4.10</cockroachdb.version>
         <version.jmh>1.37</version.jmh>
     </properties>
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -384,15 +384,6 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withImportance(Importance.LOW)
             .withDescription("Timeout in seconds for validating that an existing JDBC connection is still usable.");
 
-    public static final Field SCHEMA_NAME = Field.create("cockroachdb.schema.name")
-            .withDisplayName("Schema name")
-            .withType(Type.STRING)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 11))
-            .withDefault("public")
-            .withWidth(Width.MEDIUM)
-            .withImportance(Importance.MEDIUM)
-            .withDescription("The schema name to use for changefeed operations.");
-
     private static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("CockroachDB")
             .type(
@@ -422,7 +413,6 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     SNAPSHOT_LOCKING_MODE,
                     UNAVAILABLE_VALUE_PLACEHOLDER,
                     READ_ONLY_CONNECTION,
-                    SCHEMA_NAME,
                     CHANGEFEED_ENVELOPE,
                     CHANGEFEED_RESOLVED_INTERVAL,
                     CHANGEFEED_INCLUDE_UPDATED,
@@ -865,7 +855,8 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
     }
 
     private static class SystemTablesPredicate implements TableFilter {
-        protected static final List<String> SYSTEM_SCHEMAS = Arrays.asList("pg_catalog", "information_schema");
+        protected static final List<String> SYSTEM_SCHEMAS = Arrays.asList(
+                "pg_catalog", "information_schema", "crdb_internal", "pg_extension");
         // these are tables that may be placed in the user's schema but are system tables. This typically includes modules
         // that install system tables such as the GEO module
         protected static final List<String> SYSTEM_TABLES = List.of("spatial_ref_sys");
@@ -988,10 +979,6 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     public int getConnectionMaxRetries() {
         return config.getInteger(CONNECTION_MAX_RETRIES);
-    }
-
-    public String getSchemaName() {
-        return config.getString(SCHEMA_NAME);
     }
 
     public int getConnectionValidationTimeoutSeconds() {

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverter.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.DefaultValueConverter;
+
+/**
+ * Parses CockroachDB column default value expressions returned by JDBC metadata
+ * into typed Java objects suitable for Kafka Connect schema defaults.
+ *
+ * <p>CockroachDB annotates default expressions with a CRDB-specific {@code :::TYPE}
+ * suffix (for example {@code 'PENDING':::STRING}, {@code 0:::INT8},
+ * {@code current_timestamp():::TIMESTAMPTZ}). This converter strips the annotation,
+ * unwraps single-quoted string literals, and parses scalar values to the Java type
+ * that matches the column's logical type. Function-generated defaults
+ * ({@code current_timestamp()}, {@code gen_random_uuid()}, {@code now()},
+ * {@code unique_rowid()}, etc.) are reported as empty so the database computes them
+ * at insert time.</p>
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBDefaultValueConverter implements DefaultValueConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBDefaultValueConverter.class);
+
+    private static final Pattern CRDB_TYPE_ANNOTATION = Pattern.compile(":::[A-Za-z0-9_ ]+(\\[\\])?$");
+    private static final Pattern PG_TYPE_CAST = Pattern.compile("::[A-Za-z0-9_ ]+(\\[\\])?$");
+    private static final Pattern FUNCTION_CALL = Pattern.compile("^[A-Za-z_][A-Za-z0-9_]*\\s*\\(");
+
+    private static final Set<String> KEYWORD_DEFAULTS = new HashSet<>();
+    static {
+        KEYWORD_DEFAULTS.add("CURRENT_TIMESTAMP");
+        KEYWORD_DEFAULTS.add("CURRENT_DATE");
+        KEYWORD_DEFAULTS.add("CURRENT_TIME");
+        KEYWORD_DEFAULTS.add("LOCALTIMESTAMP");
+        KEYWORD_DEFAULTS.add("LOCALTIME");
+        KEYWORD_DEFAULTS.add("NOW");
+        KEYWORD_DEFAULTS.add("TRANSACTION_TIMESTAMP");
+        KEYWORD_DEFAULTS.add("STATEMENT_TIMESTAMP");
+    }
+
+    private final Map<String, Mapper> mappers = new HashMap<>();
+
+    public CockroachDBDefaultValueConverter() {
+        register("BOOL", (c, v) -> Boolean.parseBoolean(v));
+        register("BOOLEAN", (c, v) -> Boolean.parseBoolean(v));
+
+        register("INT2", (c, v) -> Short.parseShort(v));
+        register("SMALLINT", (c, v) -> Short.parseShort(v));
+        register("INT16", (c, v) -> Short.parseShort(v));
+
+        register("INT4", (c, v) -> Integer.parseInt(v));
+        register("INT", (c, v) -> Integer.parseInt(v));
+        register("INTEGER", (c, v) -> Integer.parseInt(v));
+        register("INT32", (c, v) -> Integer.parseInt(v));
+
+        register("INT8", (c, v) -> Long.parseLong(v));
+        register("BIGINT", (c, v) -> Long.parseLong(v));
+        register("INT64", (c, v) -> Long.parseLong(v));
+        register("SERIAL", (c, v) -> Long.parseLong(v));
+
+        register("FLOAT4", (c, v) -> Float.parseFloat(v));
+        register("REAL", (c, v) -> Float.parseFloat(v));
+
+        register("FLOAT8", (c, v) -> Double.parseDouble(v));
+        register("DOUBLE PRECISION", (c, v) -> Double.parseDouble(v));
+        register("FLOAT", (c, v) -> Double.parseDouble(v));
+
+        // DECIMAL/NUMERIC schemas are string-backed in CockroachDBValueConverterProvider
+        register("NUMERIC", (c, v) -> new BigDecimal(v).toPlainString());
+        register("DECIMAL", (c, v) -> new BigDecimal(v).toPlainString());
+        register("DEC", (c, v) -> new BigDecimal(v).toPlainString());
+
+        Mapper passthroughString = (c, v) -> v;
+        register("VARCHAR", passthroughString);
+        register("CHAR", passthroughString);
+        register("CHARACTER VARYING", passthroughString);
+        register("TEXT", passthroughString);
+        register("STRING", passthroughString);
+        register("NAME", passthroughString);
+        register("UUID", passthroughString);
+        register("INET", passthroughString);
+        register("JSON", passthroughString);
+        register("JSONB", passthroughString);
+        register("INTERVAL", passthroughString);
+        register("TIME", passthroughString);
+        register("TIMETZ", passthroughString);
+        register("TIME WITHOUT TIME ZONE", passthroughString);
+        register("TIME WITH TIME ZONE", passthroughString);
+        register("GEOGRAPHY", passthroughString);
+        register("GEOMETRY", passthroughString);
+        register("ENUM", passthroughString);
+        register("BIT", passthroughString);
+        register("VARBIT", passthroughString);
+        register("BIT VARYING", passthroughString);
+
+        register("DATE", (c, v) -> (int) LocalDate.parse(v).toEpochDay());
+
+        Mapper timestampMapper = (c, v) -> {
+            try {
+                OffsetDateTime odt = OffsetDateTime.parse(v, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                return odt.toInstant().getEpochSecond() * 1_000_000L + odt.toInstant().getNano() / 1_000L;
+            }
+            catch (DateTimeParseException ignored) {
+                java.time.Instant instant = java.time.LocalDateTime.parse(v).toInstant(ZoneOffset.UTC);
+                return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
+            }
+        };
+        register("TIMESTAMP", timestampMapper);
+        register("TIMESTAMPTZ", timestampMapper);
+        register("TIMESTAMP WITHOUT TIME ZONE", timestampMapper);
+        register("TIMESTAMP WITH TIME ZONE", timestampMapper);
+
+        register("BYTEA", (c, v) -> v.getBytes());
+        register("BYTES", (c, v) -> v.getBytes());
+        register("BLOB", (c, v) -> v.getBytes());
+
+        // pgvector-compatible VECTOR type (CockroachDB 24.2+): '[1.0,2.0,3.0]':::VECTOR
+        register("VECTOR", (c, v) -> parseVector(v));
+    }
+
+    static List<Double> parseVector(String literal) {
+        String s = literal.trim();
+        if (s.startsWith("[") && s.endsWith("]")) {
+            s = s.substring(1, s.length() - 1);
+        }
+        s = s.trim();
+        if (s.isEmpty()) {
+            return new ArrayList<>();
+        }
+        String[] parts = s.split(",");
+        List<Double> out = new ArrayList<>(parts.length);
+        for (String p : parts) {
+            out.add(Double.parseDouble(p.trim()));
+        }
+        return out;
+    }
+
+    private void register(String typeName, Mapper mapper) {
+        mappers.put(typeName.toUpperCase(Locale.ROOT), mapper);
+    }
+
+    @Override
+    public Optional<Object> parseDefaultValue(Column column, String defaultValueExpression) {
+        if (defaultValueExpression == null) {
+            return Optional.empty();
+        }
+
+        String expr = defaultValueExpression.trim();
+        if (expr.isEmpty() || "NULL".equalsIgnoreCase(expr) || expr.toUpperCase(Locale.ROOT).startsWith("NULL:")) {
+            return Optional.empty();
+        }
+
+        String stripped = stripTypeAnnotation(expr);
+
+        String upper = stripped.toUpperCase(Locale.ROOT);
+        if (KEYWORD_DEFAULTS.contains(upper) || isFunctionCall(stripped)) {
+            return Optional.empty();
+        }
+
+        String literal = unquote(stripped);
+
+        String typeName = column.typeName();
+        if (typeName == null) {
+            return Optional.empty();
+        }
+
+        String key = typeName.toUpperCase(Locale.ROOT);
+        Mapper mapper = mappers.get(key);
+        if (mapper == null && key.endsWith("[]")) {
+            // CRDB array defaults arrive as e.g. ARRAY['a','b']:::STRING[] — pass through as the raw literal
+            mapper = (c, v) -> v;
+        }
+        if (mapper == null) {
+            LOGGER.debug("No default-value mapper for CockroachDB type '{}'; skipping default", typeName);
+            return Optional.empty();
+        }
+
+        try {
+            Object parsed = mapper.parse(column, literal);
+            return Optional.ofNullable(parsed);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Cannot parse default value '{}' for column '{}' of type '{}'; ignoring",
+                    defaultValueExpression, column.name(), typeName);
+            LOGGER.debug("Default-value parsing failed", e);
+            return Optional.empty();
+        }
+    }
+
+    static String stripTypeAnnotation(String expr) {
+        String s = CRDB_TYPE_ANNOTATION.matcher(expr).replaceFirst("");
+        if (s.equals(expr)) {
+            s = PG_TYPE_CAST.matcher(expr).replaceFirst("");
+        }
+        return s.trim();
+    }
+
+    static String unquote(String expr) {
+        if (expr.length() >= 2 && expr.charAt(0) == '\'' && expr.charAt(expr.length() - 1) == '\'') {
+            String inner = expr.substring(1, expr.length() - 1);
+            return inner.replace("''", "'");
+        }
+        return expr;
+    }
+
+    static boolean isFunctionCall(String expr) {
+        return FUNCTION_CALL.matcher(expr).find();
+    }
+
+    @FunctionalInterface
+    private interface Mapper {
+        Object parse(Column column, String value) throws Exception;
+    }
+}

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSchema.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSchema.java
@@ -5,8 +5,7 @@
  */
 package io.debezium.connector.cockroachdb;
 
-import java.sql.ResultSet;
-import java.sql.Types;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -16,30 +15,27 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
 import io.debezium.connector.common.CdcSourceTaskContext;
-import io.debezium.relational.Column;
-import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.Table;
-import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchemaBuilder;
+import io.debezium.relational.Tables;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
 /**
  * Schema manager for the CockroachDB connector.
  *
- * <p>Extends Debezium's {@link RelationalDatabaseSchema} to discover tables from
- * CockroachDB's {@code information_schema} and register them with the parent so that
- * the {@link io.debezium.pipeline.EventDispatcher} can resolve table schemas at dispatch time.</p>
+ * <p>Discovers tables via {@link io.debezium.jdbc.JdbcConnection#readSchema} and registers them
+ * with the parent so the {@link io.debezium.pipeline.EventDispatcher} can resolve table schemas
+ * at dispatch time. Honors {@code schema.include.list} / {@code schema.exclude.list} and
+ * {@code table.include.list} / {@code table.exclude.list} via the inherited {@code TableFilter}.</p>
  *
  * @author Virag Tripathi
  */
 public class CockroachDBSchema extends RelationalDatabaseSchema {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSchema.class);
-
-    private final List<TableId> discoveredTables = new ArrayList<>();
 
     public CockroachDBSchema(CdcSourceTaskContext<CockroachDBConnectorConfig> cdcSourceTaskContext,
                              TopicNamingStrategy<TableId> topicNamingStrategy) {
@@ -50,7 +46,7 @@ public class CockroachDBSchema extends RelationalDatabaseSchema {
                 cdcSourceTaskContext.getConfig().getColumnFilter(),
                 new TableSchemaBuilder(
                         new CockroachDBValueConverterProvider(),
-                        null,
+                        new CockroachDBDefaultValueConverter(),
                         cdcSourceTaskContext.getConfig().schemaNameAdjuster(),
                         new CustomConverterRegistry(Collections.emptyList()),
                         cdcSourceTaskContext.getConfig().getSourceInfoStructMaker().schema(),
@@ -62,243 +58,47 @@ public class CockroachDBSchema extends RelationalDatabaseSchema {
                 cdcSourceTaskContext);
     }
 
-    /**
-     * Connects to CockroachDB, discovers tables from {@code information_schema},
-     * builds {@link Table} objects with column metadata, and registers them with
-     * the parent {@link RelationalDatabaseSchema}.
-     */
     public void initialize(CockroachDBConnectorConfig config) {
         LOGGER.info("Initializing CockroachDBSchema");
         try (CockroachDBConnection connection = new CockroachDBConnection(config)) {
             connection.connect();
-            loadAndRegisterTables(connection, config);
+            connection.readSchema(tables(), null, null, getTableFilter(), null, true);
+            refreshSchemas();
+            LOGGER.info("Schema initialization completed with {} tables", tableIds().size());
         }
-        catch (Exception e) {
+        catch (SQLException e) {
             LOGGER.error("Failed to initialize schema", e);
             throw new RuntimeException("Failed to initialize schema", e);
         }
     }
 
-    private void loadAndRegisterTables(CockroachDBConnection connection, CockroachDBConnectorConfig config) throws Exception {
-        String sql = "SELECT table_schema, table_name FROM information_schema.tables " +
-                "WHERE table_schema = ? AND table_type = 'BASE TABLE'";
-
-        try (var pstmt = connection.connection().prepareStatement(sql)) {
-            pstmt.setString(1, config.getSchemaName());
-            try (ResultSet rs = pstmt.executeQuery()) {
-                while (rs.next()) {
-                    String schemaName = rs.getString("table_schema");
-                    String tableName = rs.getString("table_name");
-                    TableId tableId = new TableId(config.getDatabaseName(), schemaName, tableName);
-
-                    Table table = buildTable(connection, tableId);
-                    if (table != null) {
-                        tables().overwriteTable(table);
-                        if (tableFor(tableId) != null) {
-                            refreshSchema(tableId);
-                            discoveredTables.add(tableId);
-                            LOGGER.info("Registered table: {} ({} columns)", tableId, table.columns().size());
-                        }
-                        else {
-                            LOGGER.debug("Table {} excluded by table filter", tableId);
-                        }
-                    }
-                }
-            }
-        }
-
-        LOGGER.info("Schema initialization completed with {} tables", discoveredTables.size());
-    }
-
-    /**
-     * Refreshes the schema for a single table by re-querying {@code information_schema}.
-     * Called when a schema change is detected during changefeed event processing.
-     *
-     * @return the refreshed {@link Table}, or {@code null} if the table no longer exists
-     */
-    public Table refreshTable(CockroachDBConnection connection, TableId tableId) throws Exception {
+    public Table refreshTable(CockroachDBConnection connection, TableId tableId) throws SQLException {
         LOGGER.info("Refreshing schema for table {}", tableId);
-        Table table = buildTable(connection, tableId);
-        if (table != null) {
-            tables().overwriteTable(table);
-            refreshSchema(tableId);
-            LOGGER.info("Schema refreshed for table {} ({} columns)", tableId, table.columns().size());
-        }
-        else {
+        Tables temp = new Tables();
+        connection.readSchema(temp, null, null, tableId::equals, null, true);
+        if (temp.size() == 0) {
             LOGGER.warn("Table {} no longer exists after schema refresh", tableId);
-        }
-        return table;
-    }
-
-    /**
-     * Queries {@code information_schema.columns} and {@code information_schema.key_column_usage}
-     * to build a complete {@link Table} with column definitions and primary key metadata.
-     */
-    private Table buildTable(CockroachDBConnection connection, TableId tableId) throws Exception {
-        TableEditor tableEditor = Table.editor().tableId(tableId);
-        List<String> pkColumns = new ArrayList<>();
-
-        String columnSql = "SELECT column_name, data_type, is_nullable, column_default, " +
-                "character_maximum_length, numeric_precision, numeric_scale, ordinal_position " +
-                "FROM information_schema.columns " +
-                "WHERE table_schema = ? AND table_name = ? " +
-                "ORDER BY ordinal_position";
-
-        try (var stmt = connection.connection().prepareStatement(columnSql)) {
-            stmt.setString(1, tableId.schema());
-            stmt.setString(2, tableId.table());
-
-            try (var rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    String columnName = rs.getString("column_name");
-                    String dataType = rs.getString("data_type");
-                    boolean nullable = "YES".equalsIgnoreCase(rs.getString("is_nullable"));
-                    int position = rs.getInt("ordinal_position");
-
-                    int maxLength = rs.getInt("character_maximum_length");
-                    int precision = rs.getInt("numeric_precision");
-                    int scale = rs.getInt("numeric_scale");
-
-                    ColumnEditor columnEditor = Column.editor()
-                            .name(columnName)
-                            .type(dataType)
-                            .jdbcType(mapCockroachDBTypeToJdbc(dataType))
-                            .optional(nullable)
-                            .position(position);
-
-                    if (maxLength > 0) {
-                        columnEditor.length(maxLength);
-                    }
-                    if (precision > 0) {
-                        columnEditor.length(precision);
-                        columnEditor.scale(scale);
-                    }
-
-                    tableEditor.addColumn(columnEditor.create());
-                    LOGGER.debug("Column {}.{}: {} (jdbc={}, nullable={}, pos={})",
-                            tableId, columnName, dataType,
-                            mapCockroachDBTypeToJdbc(dataType), nullable, position);
-                }
-            }
-        }
-
-        String pkSql = "SELECT kcu.column_name " +
-                "FROM information_schema.key_column_usage kcu " +
-                "JOIN information_schema.table_constraints tc " +
-                "  ON kcu.constraint_name = tc.constraint_name " +
-                "  AND kcu.table_schema = tc.table_schema " +
-                "  AND kcu.table_name = tc.table_name " +
-                "WHERE kcu.table_schema = ? AND kcu.table_name = ? " +
-                "AND tc.constraint_type = 'PRIMARY KEY' " +
-                "ORDER BY kcu.ordinal_position";
-
-        try (var stmt = connection.connection().prepareStatement(pkSql)) {
-            stmt.setString(1, tableId.schema());
-            stmt.setString(2, tableId.table());
-
-            try (var rs = stmt.executeQuery()) {
-                while (rs.next()) {
-                    pkColumns.add(rs.getString("column_name"));
-                }
-            }
-        }
-
-        if (!pkColumns.isEmpty()) {
-            tableEditor.setPrimaryKeyNames(pkColumns);
-        }
-
-        Table table = tableEditor.create();
-        if (table.columns().isEmpty()) {
-            LOGGER.warn("Table {} has no columns, skipping registration", tableId);
             return null;
         }
-        return table;
+        Table updatedTable = temp.forTable(tableId);
+        tables().overwriteTable(updatedTable);
+        refreshSchema(tableId);
+        LOGGER.info("Schema refreshed for table {} ({} columns)", tableId, updatedTable.columns().size());
+        return updatedTable;
     }
 
-    /**
-     * Maps CockroachDB data type names to JDBC type codes.
-     * CockroachDB uses PostgreSQL-compatible type names.
-     */
-    private static int mapCockroachDBTypeToJdbc(String dataType) {
-        if (dataType == null) {
-            return Types.OTHER;
-        }
-        switch (dataType.toUpperCase()) {
-            case "BOOL":
-            case "BOOLEAN":
-                return Types.BOOLEAN;
-            case "INT2":
-            case "SMALLINT":
-                return Types.SMALLINT;
-            case "INT4":
-            case "INTEGER":
-            case "INT":
-                return Types.INTEGER;
-            case "INT8":
-            case "BIGINT":
-                return Types.BIGINT;
-            case "FLOAT4":
-            case "REAL":
-                return Types.REAL;
-            case "FLOAT8":
-            case "DOUBLE PRECISION":
-                return Types.DOUBLE;
-            case "NUMERIC":
-            case "DECIMAL":
-                return Types.NUMERIC;
-            case "VARCHAR":
-            case "CHARACTER VARYING":
-                return Types.VARCHAR;
-            case "TEXT":
-            case "STRING":
-                return Types.VARCHAR;
-            case "CHAR":
-            case "CHARACTER":
-                return Types.CHAR;
-            case "BYTEA":
-            case "BYTES":
-                return Types.BINARY;
-            case "DATE":
-                return Types.DATE;
-            case "TIME":
-            case "TIME WITHOUT TIME ZONE":
-                return Types.TIME;
-            case "TIMETZ":
-            case "TIME WITH TIME ZONE":
-                return Types.TIME_WITH_TIMEZONE;
-            case "TIMESTAMP":
-            case "TIMESTAMP WITHOUT TIME ZONE":
-                return Types.TIMESTAMP;
-            case "TIMESTAMPTZ":
-            case "TIMESTAMP WITH TIME ZONE":
-                return Types.TIMESTAMP_WITH_TIMEZONE;
-            case "INTERVAL":
-                return Types.OTHER;
-            case "UUID":
-                return Types.OTHER;
-            case "JSONB":
-            case "JSON":
-                return Types.OTHER;
-            case "INET":
-                return Types.OTHER;
-            case "BIT":
-            case "VARBIT":
-            case "BIT VARYING":
-                return Types.BIT;
-            case "ARRAY":
-                return Types.ARRAY;
-            default:
-                return Types.OTHER;
-        }
+    private void refreshSchemas() {
+        clearSchemas();
+        tableIds().forEach(this::refreshSchema);
+    }
+
+    public List<TableId> getDiscoveredTables() {
+        return new ArrayList<>(tableIds());
     }
 
     @Override
     public void close() {
         LOGGER.info("Closing CockroachDBSchema");
         super.close();
-    }
-
-    public List<TableId> getDiscoveredTables() {
-        return discoveredTables;
     }
 }

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -63,16 +63,7 @@ public class CockroachDBSignalBasedIncrementalSnapshotChangeEventSource
     @Override
     protected Table refreshTableSchema(Table table) throws SQLException {
         LOGGER.debug("Refreshing table '{}' schema for incremental snapshot.", table.id());
-        try {
-            cockroachDBSchema.refreshTable(cockroachDBConnection, table.id());
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new SQLException("Interrupted while refreshing schema for table " + table.id(), e);
-        }
-        catch (Exception e) {
-            throw new SQLException("Failed to refresh schema for table " + table.id(), e);
-        }
+        cockroachDBSchema.refreshTable(cockroachDBConnection, table.id());
         return cockroachDBSchema.tableFor(table.id());
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverterTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+
+/**
+ * Unit tests for {@link CockroachDBDefaultValueConverter}.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBDefaultValueConverterTest {
+
+    private final CockroachDBDefaultValueConverter converter = new CockroachDBDefaultValueConverter();
+
+    @Test
+    public void shouldStripCrdbTypeAnnotation() {
+        assertThat(CockroachDBDefaultValueConverter.stripTypeAnnotation("0:::INT8")).isEqualTo("0");
+        assertThat(CockroachDBDefaultValueConverter.stripTypeAnnotation("'PENDING':::STRING")).isEqualTo("'PENDING'");
+        assertThat(CockroachDBDefaultValueConverter.stripTypeAnnotation("current_timestamp():::TIMESTAMPTZ"))
+                .isEqualTo("current_timestamp()");
+    }
+
+    @Test
+    public void shouldUnquoteSingleQuotedLiteral() {
+        assertThat(CockroachDBDefaultValueConverter.unquote("'PENDING'")).isEqualTo("PENDING");
+        assertThat(CockroachDBDefaultValueConverter.unquote("'it''s'")).isEqualTo("it's");
+        assertThat(CockroachDBDefaultValueConverter.unquote("0")).isEqualTo("0");
+    }
+
+    @Test
+    public void shouldDetectFunctionCall() {
+        assertThat(CockroachDBDefaultValueConverter.isFunctionCall("current_timestamp()")).isTrue();
+        assertThat(CockroachDBDefaultValueConverter.isFunctionCall("gen_random_uuid()")).isTrue();
+        assertThat(CockroachDBDefaultValueConverter.isFunctionCall("0")).isFalse();
+    }
+
+    @Test
+    public void shouldParseIntegerDefault() {
+        Column col = column("INT8");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "0:::INT8");
+        assertThat(parsed).isPresent().get().isInstanceOf(Long.class).isEqualTo(0L);
+    }
+
+    @Test
+    public void shouldParseBooleanDefault() {
+        Column col = column("BOOL");
+        assertThat(converter.parseDefaultValue(col, "false")).contains(Boolean.FALSE);
+        assertThat(converter.parseDefaultValue(col, "true")).contains(Boolean.TRUE);
+    }
+
+    @Test
+    public void shouldParseStringDefault() {
+        Column col = column("STRING");
+        assertThat(converter.parseDefaultValue(col, "'PENDING':::STRING")).contains("PENDING");
+    }
+
+    @Test
+    public void shouldParseDecimalDefaultAsString() {
+        Column col = column("DECIMAL");
+        assertThat(converter.parseDefaultValue(col, "1.50:::DECIMAL")).contains(new BigDecimal("1.50").toPlainString());
+    }
+
+    @Test
+    public void shouldSkipFunctionDefault() {
+        Column col = column("TIMESTAMPTZ");
+        assertThat(converter.parseDefaultValue(col, "current_timestamp():::TIMESTAMPTZ")).isEmpty();
+    }
+
+    @Test
+    public void shouldSkipNullDefault() {
+        Column col = column("INT8");
+        assertThat(converter.parseDefaultValue(col, null)).isEmpty();
+        assertThat(converter.parseDefaultValue(col, "NULL")).isEmpty();
+        assertThat(converter.parseDefaultValue(col, "NULL:::INT8")).isEmpty();
+    }
+
+    @Test
+    public void shouldParseDateAsEpochDays() {
+        Column col = column("DATE");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'2024-01-01':::DATE");
+        assertThat(parsed).isPresent().get().isInstanceOf(Integer.class);
+    }
+
+    @Test
+    public void shouldReturnEmptyForUnknownType() {
+        Column col = column("WIDGET");
+        assertThat(converter.parseDefaultValue(col, "'foo'")).isEmpty();
+    }
+
+    @Test
+    public void shouldParseVectorLiteral() {
+        List<Double> parsed = CockroachDBDefaultValueConverter.parseVector("[1.0, 2.0, 3.5]");
+        assertThat(parsed).containsExactly(1.0, 2.0, 3.5);
+    }
+
+    @Test
+    public void shouldParseVectorDefault() {
+        Column col = column("VECTOR");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'[1.0,2.0,3.0]':::VECTOR");
+        assertThat(parsed).isPresent().get().isInstanceOf(List.class);
+        @SuppressWarnings("unchecked")
+        List<Double> values = (List<Double>) parsed.get();
+        assertThat(values).containsExactly(1.0, 2.0, 3.0);
+    }
+
+    @Test
+    public void shouldParseArrayDefaultAsRawLiteral() {
+        Column col = column("STRING[]");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "ARRAY['a','b']:::STRING[]");
+        assertThat(parsed).isPresent();
+    }
+
+    private static Column column(String typeName) {
+        ColumnEditor editor = Column.editor().name("c").type(typeName);
+        return editor.create();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBCloudConnectionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBCloudConnectionIT.java
@@ -235,7 +235,6 @@ public class CockroachDBCloudConnectionIT {
                 .with("database.sslmode", sslMode)
                 .with("database.server.name", "cloud-test")
                 .with("topic.prefix", "cloud-test")
-                .with("cockroachdb.schema.name", "public")
                 .build();
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
@@ -35,7 +35,7 @@ import io.debezium.connector.cockroachdb.CockroachDBConnector;
 @Testcontainers
 public class CockroachDBConnectionIT {
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final Network NETWORK = Network.newNetwork();
 
     @Container

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
@@ -40,7 +40,7 @@ public class CockroachDBConnectorIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBConnectorIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.6");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "testdb";
     private static final String TABLE_NAME = "users";
     private static final String TOPIC_PREFIX = "test-cockroachdb";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
@@ -53,7 +53,7 @@ public class CockroachDBEndToEndIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBEndToEndIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "e2e_testdb";
     private static final String TABLE_NAME = "e2e_orders";
 
@@ -156,7 +156,6 @@ public class CockroachDBEndToEndIT {
         config.put("database.server.name", "e2e-test");
         config.put("topic.prefix", "e2e-test");
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         String bootstrapServers = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://" + bootstrapServers);

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
@@ -49,7 +49,7 @@ public class CockroachDBHeartbeatIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBHeartbeatIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "heartbeat_testdb";
     private static final String TABLE_NAME = "hb_events";
 
@@ -132,7 +132,6 @@ public class CockroachDBHeartbeatIT {
         config.put("topic.prefix", "hb-test");
         config.put("table.include.list", "public." + TABLE_NAME);
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBIncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBIncrementalSnapshotIT.java
@@ -59,7 +59,7 @@ public class CockroachDBIncrementalSnapshotIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBIncrementalSnapshotIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.6");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "inc_snap_testdb";
     private static final String TABLE_NAME = "snap_products";
     private static final String SIGNAL_TABLE = "debezium_signal";
@@ -151,7 +151,6 @@ public class CockroachDBIncrementalSnapshotIT {
         config.put("topic.prefix", "inc-snap");
         config.put("table.include.list", "public." + TABLE_NAME + ",public." + SIGNAL_TABLE);
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
@@ -53,10 +53,12 @@ public class CockroachDBMultiTableIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBMultiTableIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "multi_table_testdb";
     private static final String ORDERS_TABLE = "mt_orders";
     private static final String CUSTOMERS_TABLE = "mt_customers";
+    private static final String INVENTORY_SCHEMA = "inventory";
+    private static final String INVENTORY_TABLE = "warehouse_items";
 
     private static final Network NETWORK = Network.newNetwork();
 
@@ -107,6 +109,14 @@ public class CockroachDBMultiTableIT {
                     + "email STRING, "
                     + "tier STRING DEFAULT 'standard'"
                     + ")");
+
+            // Non-public schema for the dbz#1973 regression test
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS " + INVENTORY_SCHEMA);
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + INVENTORY_SCHEMA + "." + INVENTORY_TABLE + " ("
+                    + "sku INT PRIMARY KEY, "
+                    + "description STRING NOT NULL, "
+                    + "quantity INT DEFAULT 0"
+                    + ")");
         }
     }
 
@@ -155,7 +165,6 @@ public class CockroachDBMultiTableIT {
         config.put("topic.prefix", "mt-test");
         config.put("table.include.list", "public." + ORDERS_TABLE + ",public." + CUSTOMERS_TABLE);
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
@@ -262,7 +271,6 @@ public class CockroachDBMultiTableIT {
         config.put("topic.prefix", "mt-insert-test");
         config.put("table.include.list", "public." + ORDERS_TABLE + ",public." + CUSTOMERS_TABLE);
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
@@ -341,6 +349,118 @@ public class CockroachDBMultiTableIT {
         boolean hasCustomerRecords = topicsSeen.stream().anyMatch(t -> t.contains(CUSTOMERS_TABLE));
         assertThat(hasOrderRecords).as("Should have insert from " + ORDERS_TABLE).isTrue();
         assertThat(hasCustomerRecords).as("Should have insert from " + CUSTOMERS_TABLE).isTrue();
+    }
+
+    /**
+     * Regression test for debezium/dbz#1973: table discovery must honor
+     * {@code table.include.list} entries that reference non-public schemas.
+     * Before the fix, schema discovery only scanned a single configured schema
+     * and silently dropped any table whose qualifier was not that schema.
+     */
+    @Test
+    public void shouldCaptureEventsFromNonPublicSchema() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + ORDERS_TABLE + " VALUES (100, 'PublicOrder', 50.00, 'PENDING')");
+            stmt.execute("INSERT INTO " + INVENTORY_SCHEMA + "." + INVENTORY_TABLE
+                    + " VALUES (1001, 'widget', 42)");
+            stmt.execute("INSERT INTO " + INVENTORY_SCHEMA + "." + INVENTORY_TABLE
+                    + " VALUES (1002, 'gadget', 7)");
+        }
+        LOGGER.info("Inserted rows into public and {} schemas", INVENTORY_SCHEMA);
+
+        Thread.sleep(2000);
+
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "multi-schema-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "ms-test");
+        config.put("topic.prefix", "ms-test");
+        // Mix public and non-public schemas in a single include list
+        config.put("table.include.list",
+                "public." + ORDERS_TABLE + "," + INVENTORY_SCHEMA + "." + INVENTORY_TABLE);
+
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.envelope", "enriched");
+        config.put("cockroachdb.changefeed.enriched.properties", "source,schema");
+        config.put("cockroachdb.changefeed.include.diff", "true");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("cockroachdb.changefeed.resolved.interval", "5s");
+        config.put("snapshot.mode", "initial");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+                LOGGER.error("Task start failed: {}", e.getMessage(), e);
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+
+        List<SourceRecord> allRecords = new ArrayList<>();
+        Set<String> topicsSeen = new HashSet<>();
+        int maxAttempts = 40;
+
+        for (int i = 0; i < maxAttempts; i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null && !records.isEmpty()) {
+                    allRecords.addAll(records);
+                    for (SourceRecord record : records) {
+                        topicsSeen.add(record.topic());
+                        LOGGER.info("  Record: topic={}, key={}", record.topic(), record.key());
+                    }
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            catch (Exception e) {
+                LOGGER.warn("Poll attempt {} failed: {}", i + 1, e.getMessage());
+            }
+            Thread.sleep(1000);
+        }
+
+        LOGGER.info("Multi-schema IT collected {} SourceRecords from topics: {}",
+                allRecords.size(), topicsSeen);
+
+        assertThat(allRecords).as("Should receive records from both schemas").isNotEmpty();
+
+        boolean hasPublicRecords = topicsSeen.stream().anyMatch(t -> t.contains(ORDERS_TABLE));
+        boolean hasInventoryRecords = topicsSeen.stream().anyMatch(t -> t.contains(INVENTORY_TABLE));
+        assertThat(hasPublicRecords)
+                .as("Should have records from public." + ORDERS_TABLE).isTrue();
+        assertThat(hasInventoryRecords)
+                .as("Should have records from " + INVENTORY_SCHEMA + "." + INVENTORY_TABLE
+                        + " (regression for dbz#1973)")
+                .isTrue();
     }
 
     private SourceTaskContext createMockContext() {

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
@@ -50,7 +50,7 @@ public class CockroachDBSchemaEvolutionIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSchemaEvolutionIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.6");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "schema_evo_testdb";
     private static final String TABLE_NAME = "evo_events";
 
@@ -133,7 +133,6 @@ public class CockroachDBSchemaEvolutionIT {
         config.put("topic.prefix", "evo-test");
         config.put("table.include.list", "public." + TABLE_NAME);
 
-        config.put("cockroachdb.schema.name", "public");
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
@@ -47,7 +47,7 @@ public class CockroachDBSnapshotIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSnapshotIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "snapshot_testdb";
     private static final String TABLE_NAME = "products";
     private static final String TOPIC_PREFIX = "snapshot-test";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
@@ -47,7 +47,7 @@ public class CockroachDBStreamingIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBStreamingIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v26.1.0");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
     private static final String DATABASE_NAME = "streaming_testdb";
     private static final String TABLE_NAME = "orders";
     private static final String TOPIC_PREFIX = "streaming-test";

--- a/src/test/scripts/configs/cockroachdb-source-template.json
+++ b/src/test/scripts/configs/cockroachdb-source-template.json
@@ -8,7 +8,6 @@
     "database.password": "${DATABASE_PASSWORD:-}",
     "database.dbname": "${DATABASE_NAME:-testdb}",
     "database.server.name": "${DATABASE_SERVER_NAME:-cockroachdb}",
-    "cockroachdb.schema.name": "${SCHEMA_NAME:-public}",
     "table.include.list": "${SCHEMA_NAME:-public}.${TABLE_NAME:-products}",
     "cockroachdb.changefeed.envelope": "${CHANGEFEED_ENVELOPE:-enriched}",
     "cockroachdb.changefeed.enriched.properties": "${CHANGEFEED_ENRICHED_PROPERTIES:-source,schema}",

--- a/src/test/scripts/docker-compose.yml
+++ b/src/test/scripts/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   cockroachdb:
-    image: cockroachdb/cockroach:${COCKROACHDB_VERSION:-v25.4.6}
+    image: cockroachdb/cockroach:${COCKROACHDB_VERSION:-v25.4.10}
     hostname: cockroachdb
     container_name: cockroachdb
     command: start-single-node --insecure


### PR DESCRIPTION
Fixes debezium/dbz#1973
Fixes debezium/dbz#1975

## Summary

Two interdependent fixes reported by a CockroachDB customer that surface together when capturing tables from a non-public schema:

- **debezium/dbz#1973** — `CockroachDBSchema` was scanning only the single schema named by the (now-removed) `cockroachdb.schema.name` config, so any entry in `table.include.list` that qualified a table with a non-public schema was silently dropped. Replaced the bespoke `information_schema` query with `JdbcConnection.readSchema`, which lets the inherited `TableFilter` (driven by `schema.include.list` / `schema.exclude.list` and `table.include.list` / `table.exclude.list`) own discovery. Expanded `SystemTablesPredicate` to exclude `crdb_internal` and `pg_extension`.

- **debezium/dbz#1975** — `TableSchemaBuilder` crashed on columns with typed `DEFAULT`s such as `0:::INT8` or `'PENDING':::STRING` because the connector wired a `null` `DefaultValueConverter`. Added `CockroachDBDefaultValueConverter` that strips the CRDB type annotation, unquotes string/date/time/bytes literals, parses numeric/boolean/UUID values, handles pgvector `VECTOR` literals (e.g. `'[1.0,2.0,3.0]':::VECTOR`), and skips function-call defaults and `NULL`s. Wired into `CockroachDBSchema`.

A separate follow-up commit bumps the default CockroachDB test image to `v25.4.10` LTS.

## Changes

- Drop `cockroachdb.schema.name` config and its references across the IT suite + source template
- `CockroachDBSchema.initialize` now delegates discovery to `JdbcConnection.readSchema(..., getTableFilter(), ...)` and calls `refreshSchemas()`
- New `CockroachDBDefaultValueConverter` (+ 14 unit tests covering INT, BOOL, STRING, DECIMAL, DATE, VECTOR, ARRAY, NULL, function-call, and unknown-type paths)
- `CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.refreshTableSchema` simplified now that `refreshTable` no longer throws checked non-SQL exceptions
- `CockroachDBMultiTableIT.shouldCaptureEventsFromNonPublicSchema` — regression IT that creates `inventory.warehouse_items` with `quantity INT DEFAULT 0` and asserts events land on the inventory topic alongside `public.mt_orders`. Exercises both fixes end-to-end.
- Bump CRDB Testcontainers / docker-compose default to `v25.4.10` LTS

## Test plan

- [x] `mvn test` — all unit tests pass (incl. new `CockroachDBDefaultValueConverterTest`)
- [x] `mvn verify` — full IT suite passes locally (37 tests, 0 failures, 10 skipped): `[INFO] BUILD SUCCESS` in 8m23s
- [x] Cloud IT passes against `$CRDB_CLOUD_URL` (cloud-only test invoked via `@EnabledIfEnvironmentVariable`)
- [x] End-to-end demo (debezium-cockroachdb-examples `crdb-to-crdb`, built with `BUILD_FROM_SOURCE=true`) streams `inventory.warehouse_items` to `crdb.inventory.warehouse_items` and into the target CRDB

## Related

- Documentation updates ride along in debezium/debezium#7090 (in review)