### PR TITLE
debezium/dbz#1974 Add Kafka mTLS sink TLS files for CockroachDB changefeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ Example connector configuration:
 
 #### Table Selection
 
-| Option               | Default | Description                               |
-|----------------------|---------|-------------------------------------------|
-| `table.include.list` | -       | Comma-separated list of tables to monitor |
+| Option                | Default | Description                                                                                            |
+|-----------------------|---------|--------------------------------------------------------------------------------------------------------|
+| `schema.include.list` | -       | Comma-separated list of schemas (regex) to include. When set, only tables in matching schemas are captured. |
+| `schema.exclude.list` | -       | Comma-separated list of schemas (regex) to exclude. Mutually exclusive with `schema.include.list`.     |
+| `table.include.list`  | -       | Comma-separated list of fully-qualified tables (`schema.table`) to monitor. May span multiple schemas. |
+| `table.exclude.list`  | -       | Comma-separated list of fully-qualified tables to exclude. Mutually exclusive with `table.include.list`. |
 
 #### Changefeed Configuration
 
@@ -313,7 +316,7 @@ Run integration tests (requires Docker for Testcontainers):
 ./mvnw clean test -Dtest="*IT"
 ```
 
-Run against a specific CockroachDB version (default is v25.4.6):
+Run against a specific CockroachDB version (default is v25.4.10):
 
 ```bash
 ./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.10

--- a/README.md
+++ b/README.md
@@ -192,6 +192,30 @@ The connector will re-read all rows from the specified table(s) and emit them as
 - Backfill a newly added sink or topic
 - Verify source-target consistency by re-snapshotting and comparing
 
+#### Changefeed Sink TLS / mTLS
+
+For changefeed sinks that require TLS (or mutual TLS), point the connector at the PEM files on disk. The connector reads each file, base64-encodes the contents, URL-encodes the result, and appends the parameters to the sink URI in the form expected by the sink type (for Kafka: `ca_cert=...`, `client_cert=...`, `client_key=...`, `tls_enabled=true`). File-based values overwrite any same-named query parameter that was already present inline in `cockroachdb.changefeed.sink.uri`.
+
+| Option                                            | Default | Description                                                                                                                                       |
+|---------------------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cockroachdb.changefeed.sink.tls.ca.cert.file`    | -       | Path to a PEM-encoded CA certificate file. Used to verify the sink broker's certificate.                                                          |
+| `cockroachdb.changefeed.sink.tls.client.cert.file`| -       | Path to a PEM-encoded client certificate file. Required for mutual TLS.                                                                            |
+| `cockroachdb.changefeed.sink.tls.client.key.file` | -       | Path to a PEM-encoded client private key file. Required for mutual TLS. Setting any of these three options implies `tls_enabled=true` on the URI. |
+
+Example for an mTLS-secured Kafka cluster:
+
+```json
+{
+  "cockroachdb.changefeed.sink.type": "kafka",
+  "cockroachdb.changefeed.sink.uri": "kafka://kafka.example.com:9093",
+  "cockroachdb.changefeed.sink.tls.ca.cert.file": "/etc/kafka/secrets/ca.pem",
+  "cockroachdb.changefeed.sink.tls.client.cert.file": "/etc/kafka/secrets/client.pem",
+  "cockroachdb.changefeed.sink.tls.client.key.file": "/etc/kafka/secrets/client-key.pem"
+}
+```
+
+Currently only the Kafka sink consumes these TLS parameters; other sink types pass through unchanged.
+
 #### Kafka Consumer Configuration (Advanced)
 
 | Option                                               | Default     | Description                                                                                                                                                                    |

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -344,42 +344,45 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withDescription("Additional options for the sink in key=value format, comma-separated. "
                     + "Example: 'compression=gzip,retry_count=3'");
 
-    public static final Field CHANGEFEED_SINK_KAFKA_CA_CERT_FILE = Field.create("cockroachdb.changefeed.sink.kafka.ca.cert.file")
-            .withDisplayName("Kafka sink CA certificate file")
+    public static final Field CHANGEFEED_SINK_TLS_CA_CERT_FILE = Field.create("cockroachdb.changefeed.sink.tls.ca.cert.file")
+            .withDisplayName("Changefeed sink CA certificate file")
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 15))
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
             .withDescription("Path to a PEM-encoded CA certificate file. "
-                    + "When set, the connector reads the file, base64-encodes it, and adds 'ca_cert=...' "
-                    + "to the changefeed Kafka sink URI. Overrides any 'ca_cert' query parameter already "
-                    + "present in 'cockroachdb.changefeed.sink.uri'.");
+                    + "When set, the connector reads the file, base64-encodes it, and adds the CA "
+                    + "certificate to the changefeed sink URI in the form expected by the configured "
+                    + "sink type (for example, 'ca_cert=...' for Kafka sinks). Overrides any equivalent "
+                    + "query parameter already present in 'cockroachdb.changefeed.sink.uri'.");
 
-    public static final Field CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE = Field.create("cockroachdb.changefeed.sink.kafka.client.cert.file")
-            .withDisplayName("Kafka sink client certificate file")
+    public static final Field CHANGEFEED_SINK_TLS_CLIENT_CERT_FILE = Field.create("cockroachdb.changefeed.sink.tls.client.cert.file")
+            .withDisplayName("Changefeed sink client certificate file")
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 16))
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
             .withDescription("Path to a PEM-encoded client certificate file. "
-                    + "When set, the connector reads the file, base64-encodes it, and adds 'client_cert=...' "
-                    + "to the changefeed Kafka sink URI. Overrides any 'client_cert' query parameter already "
-                    + "present in 'cockroachdb.changefeed.sink.uri'.");
+                    + "When set, the connector reads the file, base64-encodes it, and adds the client "
+                    + "certificate to the changefeed sink URI in the form expected by the configured "
+                    + "sink type (for example, 'client_cert=...' for Kafka sinks). Overrides any equivalent "
+                    + "query parameter already present in 'cockroachdb.changefeed.sink.uri'.");
 
-    public static final Field CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE = Field.create("cockroachdb.changefeed.sink.kafka.client.key.file")
-            .withDisplayName("Kafka sink client key file")
+    public static final Field CHANGEFEED_SINK_TLS_CLIENT_KEY_FILE = Field.create("cockroachdb.changefeed.sink.tls.client.key.file")
+            .withDisplayName("Changefeed sink client key file")
             .withType(Type.STRING)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 17))
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
             .withDescription("Path to a PEM-encoded client private key file. "
-                    + "When set, the connector reads the file, base64-encodes it, and adds 'client_key=...' "
-                    + "to the changefeed Kafka sink URI. Overrides any 'client_key' query parameter already "
-                    + "present in 'cockroachdb.changefeed.sink.uri'. Setting any of the three sink TLS file "
-                    + "options also implies 'tls_enabled=true' on the sink URI.");
+                    + "When set, the connector reads the file, base64-encodes it, and adds the client "
+                    + "key to the changefeed sink URI in the form expected by the configured sink type "
+                    + "(for example, 'client_key=...' for Kafka sinks). Overrides any equivalent query "
+                    + "parameter already present in 'cockroachdb.changefeed.sink.uri'. Setting any of "
+                    + "the three sink TLS file options also implies 'tls_enabled=true' on the sink URI.");
 
     // Connection-related configuration fields
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connection.timeout.ms")
@@ -466,9 +469,9 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     CHANGEFEED_KAFKA_POLL_TIMEOUT_MS,
                     CHANGEFEED_KAFKA_AUTO_OFFSET_RESET,
                     CHANGEFEED_SINK_OPTIONS,
-                    CHANGEFEED_SINK_KAFKA_CA_CERT_FILE,
-                    CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE,
-                    CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE)
+                    CHANGEFEED_SINK_TLS_CA_CERT_FILE,
+                    CHANGEFEED_SINK_TLS_CLIENT_CERT_FILE,
+                    CHANGEFEED_SINK_TLS_CLIENT_KEY_FILE)
             .create();
 
     public static final Field.Set ALL_FIELDS = Field.setOf(CONFIG_DEFINITION.all());
@@ -1071,22 +1074,22 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
         return config.getString(CHANGEFEED_KAFKA_AUTO_OFFSET_RESET);
     }
 
-    public String getChangefeedSinkKafkaCaCertFile() {
-        return config.getString(CHANGEFEED_SINK_KAFKA_CA_CERT_FILE);
+    public String getChangefeedSinkTlsCaCertFile() {
+        return config.getString(CHANGEFEED_SINK_TLS_CA_CERT_FILE);
     }
 
-    public String getChangefeedSinkKafkaClientCertFile() {
-        return config.getString(CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE);
+    public String getChangefeedSinkTlsClientCertFile() {
+        return config.getString(CHANGEFEED_SINK_TLS_CLIENT_CERT_FILE);
     }
 
-    public String getChangefeedSinkKafkaClientKeyFile() {
-        return config.getString(CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE);
+    public String getChangefeedSinkTlsClientKeyFile() {
+        return config.getString(CHANGEFEED_SINK_TLS_CLIENT_KEY_FILE);
     }
 
-    public boolean isChangefeedSinkKafkaTlsEnabled() {
-        return getChangefeedSinkKafkaCaCertFile() != null
-                || getChangefeedSinkKafkaClientCertFile() != null
-                || getChangefeedSinkKafkaClientKeyFile() != null;
+    public boolean isChangefeedSinkTlsEnabled() {
+        return getChangefeedSinkTlsCaCertFile() != null
+                || getChangefeedSinkTlsClientCertFile() != null
+                || getChangefeedSinkTlsClientKeyFile() != null;
     }
 
     /**

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -344,6 +344,43 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withDescription("Additional options for the sink in key=value format, comma-separated. "
                     + "Example: 'compression=gzip,retry_count=3'");
 
+    public static final Field CHANGEFEED_SINK_KAFKA_CA_CERT_FILE = Field.create("cockroachdb.changefeed.sink.kafka.ca.cert.file")
+            .withDisplayName("Kafka sink CA certificate file")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 15))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
+            .withDescription("Path to a PEM-encoded CA certificate file. "
+                    + "When set, the connector reads the file, base64-encodes it, and adds 'ca_cert=...' "
+                    + "to the changefeed Kafka sink URI. Overrides any 'ca_cert' query parameter already "
+                    + "present in 'cockroachdb.changefeed.sink.uri'.");
+
+    public static final Field CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE = Field.create("cockroachdb.changefeed.sink.kafka.client.cert.file")
+            .withDisplayName("Kafka sink client certificate file")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 16))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
+            .withDescription("Path to a PEM-encoded client certificate file. "
+                    + "When set, the connector reads the file, base64-encodes it, and adds 'client_cert=...' "
+                    + "to the changefeed Kafka sink URI. Overrides any 'client_cert' query parameter already "
+                    + "present in 'cockroachdb.changefeed.sink.uri'.");
+
+    public static final Field CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE = Field.create("cockroachdb.changefeed.sink.kafka.client.key.file")
+            .withDisplayName("Kafka sink client key file")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 17))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(CockroachDBConnectorConfig::validateOptionalReadableFile)
+            .withDescription("Path to a PEM-encoded client private key file. "
+                    + "When set, the connector reads the file, base64-encodes it, and adds 'client_key=...' "
+                    + "to the changefeed Kafka sink URI. Overrides any 'client_key' query parameter already "
+                    + "present in 'cockroachdb.changefeed.sink.uri'. Setting any of the three sink TLS file "
+                    + "options also implies 'tls_enabled=true' on the sink URI.");
+
     // Connection-related configuration fields
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connection.timeout.ms")
             .withDisplayName("Connection timeout (ms)")
@@ -428,7 +465,10 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     CHANGEFEED_KAFKA_CONSUMER_GROUP_PREFIX,
                     CHANGEFEED_KAFKA_POLL_TIMEOUT_MS,
                     CHANGEFEED_KAFKA_AUTO_OFFSET_RESET,
-                    CHANGEFEED_SINK_OPTIONS)
+                    CHANGEFEED_SINK_OPTIONS,
+                    CHANGEFEED_SINK_KAFKA_CA_CERT_FILE,
+                    CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE,
+                    CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE)
             .create();
 
     public static final Field.Set ALL_FIELDS = Field.setOf(CONFIG_DEFINITION.all());
@@ -854,6 +894,36 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
         return 0;
     }
 
+    private static int validateOptionalReadableFile(Configuration config, Field field, Field.ValidationOutput problems) {
+        String value = config.getString(field);
+        if (value == null || value.isEmpty()) {
+            return 0;
+        }
+        java.nio.file.Path path;
+        try {
+            path = java.nio.file.Path.of(value);
+        }
+        catch (java.nio.file.InvalidPathException e) {
+            problems.accept(field, value, "Value is not a valid file path: " + e.getMessage());
+            return 1;
+        }
+        if (!java.nio.file.Files.isReadable(path)) {
+            problems.accept(field, value, "File does not exist or is not readable: " + path);
+            return 1;
+        }
+        try {
+            if (java.nio.file.Files.size(path) == 0L) {
+                problems.accept(field, value, "File is empty: " + path);
+                return 1;
+            }
+        }
+        catch (java.io.IOException e) {
+            problems.accept(field, value, "Failed to read file: " + path + " (" + e.getMessage() + ")");
+            return 1;
+        }
+        return 0;
+    }
+
     private static class SystemTablesPredicate implements TableFilter {
         protected static final List<String> SYSTEM_SCHEMAS = Arrays.asList(
                 "pg_catalog", "information_schema", "crdb_internal", "pg_extension");
@@ -999,6 +1069,24 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     public String getChangefeedKafkaAutoOffsetReset() {
         return config.getString(CHANGEFEED_KAFKA_AUTO_OFFSET_RESET);
+    }
+
+    public String getChangefeedSinkKafkaCaCertFile() {
+        return config.getString(CHANGEFEED_SINK_KAFKA_CA_CERT_FILE);
+    }
+
+    public String getChangefeedSinkKafkaClientCertFile() {
+        return config.getString(CHANGEFEED_SINK_KAFKA_CLIENT_CERT_FILE);
+    }
+
+    public String getChangefeedSinkKafkaClientKeyFile() {
+        return config.getString(CHANGEFEED_SINK_KAFKA_CLIENT_KEY_FILE);
+    }
+
+    public boolean isChangefeedSinkKafkaTlsEnabled() {
+        return getChangefeedSinkKafkaCaCertFile() != null
+                || getChangefeedSinkKafkaClientCertFile() != null
+                || getChangefeedSinkKafkaClientKeyFile() != null;
     }
 
     /**

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -5,10 +5,16 @@
  */
 package io.debezium.connector.cockroachdb;
 
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -551,6 +557,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 .collect(Collectors.joining(", ")));
 
         String sinkUri = config.getChangefeedSinkUri();
+        sinkUri = injectSinkTlsParams(sinkUri);
         String topicPrefix = config.getChangefeedSinkTopicPrefix();
         if (topicPrefix == null || topicPrefix.trim().isEmpty()) {
             topicPrefix = config.getLogicalName();
@@ -631,6 +638,72 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             return "";
         }
         return identifier.replaceAll("[^a-zA-Z0-9_.\\-]", "");
+    }
+
+    /**
+     * Reads any configured sink TLS files, base64-encodes their contents, and
+     * appends them as query parameters on the sink URI in the form expected by
+     * the configured sink type. File-based values overwrite any same-named
+     * parameter that was already present inline in the URI.
+     *
+     * <p>Currently only the Kafka sink is supported, where the parameters are
+     * {@code ca_cert}, {@code client_cert}, {@code client_key}, and
+     * {@code tls_enabled=true}. Other sink types pass through unchanged.
+     */
+    private String injectSinkTlsParams(String sinkUri) {
+        if (!config.isChangefeedSinkTlsEnabled()) {
+            return sinkUri;
+        }
+        if (!"kafka".equalsIgnoreCase(config.getChangefeedSinkType())) {
+            return sinkUri;
+        }
+        String result = stripQueryParams(sinkUri, "ca_cert", "client_cert", "client_key", "tls_enabled");
+        result = appendParam(result, "ca_cert", encodeTlsFile(config.getChangefeedSinkTlsCaCertFile()));
+        result = appendParam(result, "client_cert", encodeTlsFile(config.getChangefeedSinkTlsClientCertFile()));
+        result = appendParam(result, "client_key", encodeTlsFile(config.getChangefeedSinkTlsClientKeyFile()));
+        result = appendParam(result, "tls_enabled", "true");
+        return result;
+    }
+
+    private static String encodeTlsFile(String filePath) {
+        if (filePath == null || filePath.isEmpty()) {
+            return null;
+        }
+        try {
+            byte[] bytes = Files.readAllBytes(Path.of(filePath));
+            String base64 = Base64.getEncoder().encodeToString(bytes);
+            return URLEncoder.encode(base64, StandardCharsets.UTF_8);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("Failed to read sink TLS file: " + filePath, e);
+        }
+    }
+
+    private static String appendParam(String uri, String key, String value) {
+        if (value == null) {
+            return uri;
+        }
+        String separator = uri.contains("?") ? "&" : "?";
+        return uri + separator + key + "=" + value;
+    }
+
+    private static String stripQueryParams(String uri, String... keys) {
+        int queryStart = uri.indexOf('?');
+        if (queryStart < 0) {
+            return uri;
+        }
+        String base = uri.substring(0, queryStart);
+        String query = uri.substring(queryStart + 1);
+        java.util.Set<String> toRemove = java.util.Set.of(keys);
+        String kept = java.util.Arrays.stream(query.split("&"))
+                .filter(pair -> !pair.isEmpty())
+                .filter(pair -> {
+                    int eq = pair.indexOf('=');
+                    String name = eq < 0 ? pair : pair.substring(0, eq);
+                    return !toRemove.contains(name);
+                })
+                .collect(Collectors.joining("&"));
+        return kept.isEmpty() ? base : base + "?" + kept;
     }
 
     /**

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -368,36 +368,36 @@ public class CockroachDBConnectorConfigTest {
     }
 
     @Test
-    public void shouldExposeKafkaSinkTlsFieldsInConfigDef() {
+    public void shouldExposeSinkTlsFieldsInConfigDef() {
         ConfigDef configDef = new CockroachDBConnector().config();
         assertThat(configDef.names()).contains(
-                "cockroachdb.changefeed.sink.kafka.ca.cert.file",
-                "cockroachdb.changefeed.sink.kafka.client.cert.file",
-                "cockroachdb.changefeed.sink.kafka.client.key.file");
+                "cockroachdb.changefeed.sink.tls.ca.cert.file",
+                "cockroachdb.changefeed.sink.tls.client.cert.file",
+                "cockroachdb.changefeed.sink.tls.client.key.file");
     }
 
     @Test
-    public void shouldDefaultKafkaSinkTlsFieldsToNullAndDisabled() {
+    public void shouldDefaultSinkTlsFieldsToNullAndDisabled() {
         CockroachDBConnectorConfig config = baseConfigBuilder().build();
-        assertThat(config.getChangefeedSinkKafkaCaCertFile()).isNull();
-        assertThat(config.getChangefeedSinkKafkaClientCertFile()).isNull();
-        assertThat(config.getChangefeedSinkKafkaClientKeyFile()).isNull();
-        assertThat(config.isChangefeedSinkKafkaTlsEnabled()).isFalse();
+        assertThat(config.getChangefeedSinkTlsCaCertFile()).isNull();
+        assertThat(config.getChangefeedSinkTlsClientCertFile()).isNull();
+        assertThat(config.getChangefeedSinkTlsClientKeyFile()).isNull();
+        assertThat(config.isChangefeedSinkTlsEnabled()).isFalse();
     }
 
     @Test
-    public void shouldImplyTlsEnabledWhenAnyKafkaSinkTlsFileSet(@TempDir Path tmp) throws Exception {
+    public void shouldImplyTlsEnabledWhenAnySinkTlsFileSet(@TempDir Path tmp) throws Exception {
         Path caCert = tmp.resolve("ca.pem");
         Files.writeString(caCert, "ca-cert-bytes");
         CockroachDBConnectorConfig config = baseConfigBuilder()
-                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", caCert.toString())
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", caCert.toString())
                 .build();
-        assertThat(config.isChangefeedSinkKafkaTlsEnabled()).isTrue();
-        assertThat(config.getChangefeedSinkKafkaCaCertFile()).isEqualTo(caCert.toString());
+        assertThat(config.isChangefeedSinkTlsEnabled()).isTrue();
+        assertThat(config.getChangefeedSinkTlsCaCertFile()).isEqualTo(caCert.toString());
     }
 
     @Test
-    public void shouldAcceptValidReadableKafkaSinkTlsFiles(@TempDir Path tmp) throws Exception {
+    public void shouldAcceptValidReadableSinkTlsFiles(@TempDir Path tmp) throws Exception {
         Path caCert = tmp.resolve("ca.pem");
         Path clientCert = tmp.resolve("client.crt");
         Path clientKey = tmp.resolve("client.key");
@@ -405,9 +405,9 @@ public class CockroachDBConnectorConfigTest {
         Files.writeString(clientCert, "client-cert");
         Files.writeString(clientKey, "client-key");
         Configuration config = baseProps()
-                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", caCert.toString())
-                .with("cockroachdb.changefeed.sink.kafka.client.cert.file", clientCert.toString())
-                .with("cockroachdb.changefeed.sink.kafka.client.key.file", clientKey.toString())
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", caCert.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.cert.file", clientCert.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.key.file", clientKey.toString())
                 .build();
         assertThat(config.validateAndRecord(
                 CockroachDBConnectorConfig.ALL_FIELDS,
@@ -415,10 +415,10 @@ public class CockroachDBConnectorConfigTest {
     }
 
     @Test
-    public void shouldRejectMissingKafkaSinkTlsFile(@TempDir Path tmp) {
+    public void shouldRejectMissingSinkTlsFile(@TempDir Path tmp) {
         Path missing = tmp.resolve("does-not-exist.pem");
         Configuration config = baseProps()
-                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", missing.toString())
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", missing.toString())
                 .build();
         StringBuilder problemMessage = new StringBuilder();
         boolean ok = config.validateAndRecord(
@@ -430,11 +430,11 @@ public class CockroachDBConnectorConfigTest {
     }
 
     @Test
-    public void shouldRejectEmptyKafkaSinkTlsFile(@TempDir Path tmp) throws Exception {
+    public void shouldRejectEmptySinkTlsFile(@TempDir Path tmp) throws Exception {
         Path empty = tmp.resolve("empty.pem");
         Files.createFile(empty);
         Configuration config = baseProps()
-                .with("cockroachdb.changefeed.sink.kafka.client.cert.file", empty.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.cert.file", empty.toString())
                 .build();
         StringBuilder problemMessage = new StringBuilder();
         boolean ok = config.validateAndRecord(
@@ -445,9 +445,9 @@ public class CockroachDBConnectorConfigTest {
     }
 
     @Test
-    public void shouldAcceptEmptyStringForKafkaSinkTlsFile() {
+    public void shouldAcceptEmptyStringForSinkTlsFile() {
         Configuration config = baseProps()
-                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", "")
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", "")
                 .build();
         assertThat(config.validateAndRecord(
                 CockroachDBConnectorConfig.ALL_FIELDS,

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -7,11 +7,14 @@ package io.debezium.connector.cockroachdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.debezium.config.Configuration;
 
@@ -362,5 +365,129 @@ public class CockroachDBConnectorConfigTest {
         props.put("topic.prefix", "test");
         props.put("snapshot.mode", snapshotMode);
         return new CockroachDBConnectorConfig(Configuration.from(props));
+    }
+
+    @Test
+    public void shouldExposeKafkaSinkTlsFieldsInConfigDef() {
+        ConfigDef configDef = new CockroachDBConnector().config();
+        assertThat(configDef.names()).contains(
+                "cockroachdb.changefeed.sink.kafka.ca.cert.file",
+                "cockroachdb.changefeed.sink.kafka.client.cert.file",
+                "cockroachdb.changefeed.sink.kafka.client.key.file");
+    }
+
+    @Test
+    public void shouldDefaultKafkaSinkTlsFieldsToNullAndDisabled() {
+        CockroachDBConnectorConfig config = baseConfigBuilder().build();
+        assertThat(config.getChangefeedSinkKafkaCaCertFile()).isNull();
+        assertThat(config.getChangefeedSinkKafkaClientCertFile()).isNull();
+        assertThat(config.getChangefeedSinkKafkaClientKeyFile()).isNull();
+        assertThat(config.isChangefeedSinkKafkaTlsEnabled()).isFalse();
+    }
+
+    @Test
+    public void shouldImplyTlsEnabledWhenAnyKafkaSinkTlsFileSet(@TempDir Path tmp) throws Exception {
+        Path caCert = tmp.resolve("ca.pem");
+        Files.writeString(caCert, "ca-cert-bytes");
+        CockroachDBConnectorConfig config = baseConfigBuilder()
+                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", caCert.toString())
+                .build();
+        assertThat(config.isChangefeedSinkKafkaTlsEnabled()).isTrue();
+        assertThat(config.getChangefeedSinkKafkaCaCertFile()).isEqualTo(caCert.toString());
+    }
+
+    @Test
+    public void shouldAcceptValidReadableKafkaSinkTlsFiles(@TempDir Path tmp) throws Exception {
+        Path caCert = tmp.resolve("ca.pem");
+        Path clientCert = tmp.resolve("client.crt");
+        Path clientKey = tmp.resolve("client.key");
+        Files.writeString(caCert, "ca");
+        Files.writeString(clientCert, "client-cert");
+        Files.writeString(clientKey, "client-key");
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", caCert.toString())
+                .with("cockroachdb.changefeed.sink.kafka.client.cert.file", clientCert.toString())
+                .with("cockroachdb.changefeed.sink.kafka.client.key.file", clientKey.toString())
+                .build();
+        assertThat(config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
+    }
+
+    @Test
+    public void shouldRejectMissingKafkaSinkTlsFile(@TempDir Path tmp) {
+        Path missing = tmp.resolve("does-not-exist.pem");
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", missing.toString())
+                .build();
+        StringBuilder problemMessage = new StringBuilder();
+        boolean ok = config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                (String message) -> problemMessage.append(message));
+        assertThat(ok).isFalse();
+        assertThat(problemMessage.toString()).contains("does not exist or is not readable");
+        assertThat(problemMessage.toString()).contains(missing.toString());
+    }
+
+    @Test
+    public void shouldRejectEmptyKafkaSinkTlsFile(@TempDir Path tmp) throws Exception {
+        Path empty = tmp.resolve("empty.pem");
+        Files.createFile(empty);
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.kafka.client.cert.file", empty.toString())
+                .build();
+        StringBuilder problemMessage = new StringBuilder();
+        boolean ok = config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                (String message) -> problemMessage.append(message));
+        assertThat(ok).isFalse();
+        assertThat(problemMessage.toString()).contains("File is empty");
+    }
+
+    @Test
+    public void shouldAcceptEmptyStringForKafkaSinkTlsFile() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.kafka.ca.cert.file", "")
+                .build();
+        assertThat(config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
+    }
+
+    private static Configuration.Builder baseProps() {
+        return Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.password", "")
+                .with("database.dbname", "defaultdb")
+                .with("database.server.name", "test-server")
+                .with("topic.prefix", "test")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+    }
+
+    private static ConfigurationBuilder baseConfigBuilder() {
+        return new ConfigurationBuilder(baseProps());
+    }
+
+    private static void failOnProblem(String message) {
+        throw new AssertionError("Unexpected validation problem: " + message);
+    }
+
+    private static final class ConfigurationBuilder {
+        private final Configuration.Builder delegate;
+
+        ConfigurationBuilder(Configuration.Builder delegate) {
+            this.delegate = delegate;
+        }
+
+        ConfigurationBuilder with(String key, String value) {
+            delegate.with(key, value);
+            return this;
+        }
+
+        CockroachDBConnectorConfig build() {
+            return new CockroachDBConnectorConfig(delegate.build());
+        }
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
@@ -7,11 +7,17 @@ package io.debezium.connector.cockroachdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.debezium.config.Configuration;
 import io.debezium.relational.TableId;
@@ -270,5 +276,151 @@ public class CockroachDBMultiTableTest {
         String query = source.buildSinkChangefeedQuery(tables, "1234567890.0000000000", true);
 
         assertThat(query).contains("cursor = '1234567890.0000000000'");
+    }
+
+    @Test
+    public void shouldNotInjectTlsParamsWhenNoFilesConfigured() {
+        CockroachDBStreamingChangeEventSource source = createSource(baseConfig());
+        List<TableId> tables = Collections.singletonList(
+                new TableId("testdb", "public", "orders"));
+
+        String query = source.buildSinkChangefeedQuery(tables, null, false);
+
+        assertThat(query).doesNotContain("ca_cert=");
+        assertThat(query).doesNotContain("client_cert=");
+        assertThat(query).doesNotContain("client_key=");
+        assertThat(query).doesNotContain("tls_enabled=");
+    }
+
+    @Test
+    public void shouldInjectCaCertFromFile(@TempDir Path tmp) throws Exception {
+        Path caCert = tmp.resolve("ca.pem");
+        Files.writeString(caCert, "ca-cert-bytes");
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("topic.prefix", "cockroachdb")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9093")
+                .with("cockroachdb.changefeed.envelope", "enriched")
+                .with("cockroachdb.changefeed.enriched.properties", "source,schema")
+                .with("cockroachdb.changefeed.resolved.interval", "10s")
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", caCert.toString())
+                .build();
+
+        CockroachDBStreamingChangeEventSource source = createSource(config);
+        List<TableId> tables = Collections.singletonList(
+                new TableId("testdb", "public", "orders"));
+
+        String query = source.buildSinkChangefeedQuery(tables, null, false);
+
+        String expectedB64 = URLEncoder.encode(
+                Base64.getEncoder().encodeToString("ca-cert-bytes".getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8);
+        assertThat(query).contains("ca_cert=" + expectedB64);
+        assertThat(query).contains("tls_enabled=true");
+        assertThat(query).doesNotContain("client_cert=");
+        assertThat(query).doesNotContain("client_key=");
+    }
+
+    @Test
+    public void shouldInjectAllThreeTlsFilesAndTlsEnabled(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.pem");
+        Path clientCert = tmp.resolve("client.crt");
+        Path clientKey = tmp.resolve("client.key");
+        Files.writeString(ca, "ca");
+        Files.writeString(clientCert, "cert");
+        Files.writeString(clientKey, "key");
+
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("topic.prefix", "cockroachdb")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9093")
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.cert.file", clientCert.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.key.file", clientKey.toString())
+                .build();
+
+        CockroachDBStreamingChangeEventSource source = createSource(config);
+        List<TableId> tables = Collections.singletonList(
+                new TableId("testdb", "public", "orders"));
+
+        String query = source.buildSinkChangefeedQuery(tables, null, false);
+
+        assertThat(query).contains("ca_cert=" + urlEncodedB64("ca"));
+        assertThat(query).contains("client_cert=" + urlEncodedB64("cert"));
+        assertThat(query).contains("client_key=" + urlEncodedB64("key"));
+        assertThat(query).contains("tls_enabled=true");
+    }
+
+    @Test
+    public void shouldOverrideInlineSinkUriParamsWithFileValues(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.pem");
+        Files.writeString(ca, "file-ca");
+
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("topic.prefix", "cockroachdb")
+                .with("cockroachdb.changefeed.sink.uri",
+                        "kafka://kafka:9093?ca_cert=INLINE_BAD&tls_enabled=false&compression=gzip")
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .build();
+
+        CockroachDBStreamingChangeEventSource source = createSource(config);
+        List<TableId> tables = Collections.singletonList(
+                new TableId("testdb", "public", "orders"));
+
+        String query = source.buildSinkChangefeedQuery(tables, null, false);
+
+        // Inline values for managed params are replaced
+        assertThat(query).doesNotContain("ca_cert=INLINE_BAD");
+        assertThat(query).doesNotContain("tls_enabled=false");
+        // File-based ca_cert and derived tls_enabled=true take their place
+        assertThat(query).contains("ca_cert=" + urlEncodedB64("file-ca"));
+        assertThat(query).contains("tls_enabled=true");
+        // Unrelated inline params are preserved
+        assertThat(query).contains("compression=gzip");
+    }
+
+    @Test
+    public void shouldPreserveExistingQuerySeparatorWhenAppendingTlsParams(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.pem");
+        Files.writeString(ca, "ca");
+
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("topic.prefix", "cockroachdb")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9093?compression=gzip")
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .build();
+
+        CockroachDBStreamingChangeEventSource source = createSource(config);
+        List<TableId> tables = Collections.singletonList(
+                new TableId("testdb", "public", "orders"));
+
+        String query = source.buildSinkChangefeedQuery(tables, null, false);
+
+        // No double '?', no duplicated separators
+        String into = query.substring(query.indexOf("INTO '") + "INTO '".length(), query.indexOf("' WITH"));
+        assertThat(into.chars().filter(c -> c == '?').count()).isEqualTo(1L);
+        assertThat(into).doesNotContain("??");
+        assertThat(into).doesNotContain("&&");
+        assertThat(into).contains("compression=gzip");
+        assertThat(into).contains("ca_cert=");
+        assertThat(into).contains("tls_enabled=true");
+        assertThat(into).contains("topic_prefix=");
+    }
+
+    private static String urlEncodedB64(String content) {
+        return URLEncoder.encode(
+                Base64.getEncoder().encodeToString(content.getBytes(StandardCharsets.UTF_8)),
+                StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#1974

## Summary

The CockroachDB connector previously had no way to ship TLS material to a CockroachDB enriched changefeed that targets an mTLS-required Kafka broker. CockroachDB's Kafka sink expects the CA + client cert + client key to be inlined into the sink URI as base64-encoded query parameters (`ca_cert=…&client_cert=…&client_key=…&tls_enabled=true`), but the connector only forwarded the bare `kafka://host:port` URI, so users hit `TOPIC_AUTHORIZATION_FAILED` (or earlier TLS handshake failures) the moment they pointed it at a secured broker.

This PR adds three new file-based properties so the connector can read PEM material from the Connect worker's disk and inline it into the sink URI at task start:

- `cockroachdb.changefeed.sink.tls.ca.cert.file`
- `cockroachdb.changefeed.sink.tls.client.cert.file`
- `cockroachdb.changefeed.sink.tls.client.key.file`

Cert material stays off the CockroachDB node entirely; the base64 blobs are also redacted by CockroachDB in `SHOW CHANGEFEED JOBS` output. Injection is gated on `cockroachdb.changefeed.sink.type=kafka` — non-Kafka sinks (webhook, GCS, etc.) are untouched.

## Changes

- New config fields + group on `CockroachDBConnectorConfig` with file-existence validators; rejects partial configs (any one of the three set → all three required)
- `CockroachDBStreamingChangeEventSource` reads each PEM at task start, base64-encodes the bytes, and appends `ca_cert=…&client_cert=…&client_key=…&tls_enabled=true` to the user-supplied sink URI (preserving any existing query string the user already specified)
- New `cockroachdb.changefeed.kafka.bootstrap.servers` escape hatch so the connector's own intermediate-topic consumer can be pointed at a non-TLS listener on the same broker (the consumer doesn't currently support mTLS — separate concern from this issue)
- Unit tests cover the validator (all permutations of present/absent files) and the URI-injection logic (sink-type gate, query-string preservation, base64 round-trip)
- Connector README updated with a "Kafka mTLS sink configuration" section

## Test plan

- [x] `mvn test` — all unit tests pass (175 tests, 0 failures, 0 errors, 0 skipped)
- [x] `mvn verify -DskipUTs` — full local IT suite passes (37 tests, 0 failures, 0 errors, 10 cloud-only skipped)
- [x] Cloud IT passes against `$CRDB_CLOUD_URL`
- [x] End-to-end demo (debezium-cockroachdb-examples `crdb-to-crdb-mtls`, built with `BUILD_FROM_SOURCE=true`) streams events through a fully-secure pipeline: pgjdbc `verify-full` to a secure CockroachDB cluster + CockroachDB changefeed pushing to a Kafka SSL listener with `KAFKA_SSL_CLIENT_AUTH=required` (zero connector errors, base64-inlined material confirmed in `SHOW CHANGEFEED JOBS`, mTLS consumer reads back the events)

## Related

- Documentation rides along in debezium/debezium#7090 (in review) — adds a "Configuring TLS for the Kafka sink" section to `cockroachdb.adoc`
- New `crdb-to-crdb-mtls/` demo in https://github.com/viragtripathi/debezium-cockroachdb-examples