### PR TITLE
debezium/dbz#2013 #2014 Literal topic prefix + optional changefeed splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ The Debezium CockroachDB connector processes row-level changes from CockroachDB 
 
 The connector uses a two-stage Kafka architecture:
 
-1. **CockroachDB changefeed -> Intermediate Kafka**: The connector creates a single CockroachDB changefeed covering all configured tables (`CREATE CHANGEFEED FOR table1, table2, ...`) with the `enriched` envelope format. CockroachDB automatically routes events to per-table Kafka topics in the intermediate cluster. The enriched format includes both schema metadata and the full before/after row state.
+1. **CockroachDB changefeed -> Intermediate Kafka**: By default the connector creates a single CockroachDB changefeed covering all configured tables (`CREATE CHANGEFEED FOR table1, table2, ...`) with the `enriched` envelope format. CockroachDB automatically routes events to per-table Kafka topics in the intermediate cluster. The enriched format includes both schema metadata and the full before/after row state.
 
 2. **Intermediate Kafka -> Debezium -> Output Kafka**: The connector subscribes to all per-table Kafka topics in a single KafkaConsumer, routes each event to the correct table based on the topic name, transforms the enriched changefeed events into the standard Debezium envelope format (with `before`, `after`, `source`, and `op` fields), and produces them to the final output Kafka topics.
 
-Using a single multi-table changefeed is the [recommended approach](https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations) to stay within CockroachDB's limit of approximately 80 changefeed jobs per cluster.
+Consolidating tables into one changefeed keeps the connector to a single changefeed job, which helps stay within CockroachDB's [recommended limit](https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations) on the number of changefeeds per cluster (around 80 at the time of writing). However, CockroachDB also [advises against](https://www.cockroachlabs.com/docs/stable/changefeed-best-practices) putting very many tables in a single changefeed, because their performance becomes coupled. For large table counts, set `cockroachdb.changefeed.max.tables.per.changefeed` to split the tables across several changefeeds, or run multiple connector instances each capturing a related subset of tables.
 
 **Status**: This connector is currently in incubation phase and is being developed and tested.
 
@@ -118,8 +118,9 @@ Example connector configuration:
 |----------------------------------------------|----------|-----------------------------------------------|
 | `cockroachdb.changefeed.enriched.properties` | source   | Comma-separated enriched properties (passthrough to CockroachDB) |
 | `cockroachdb.changefeed.sink.type`           | kafka    | Sink type (kafka, webhook, pubsub, etc.)      |
-| `cockroachdb.changefeed.sink.uri`            | -        | Sink URI (required). e.g. `kafka://host:port` |
-| `cockroachdb.changefeed.sink.topic.prefix`   | ""       | Prefix for intermediate changefeed Kafka topic names. If empty, defaults to `topic.prefix` |
+| `cockroachdb.changefeed.sink.uri`            | -        | Sink URI (required). e.g. `kafka://host:port`. Do not set `topic_name`/`topic_prefix` here |
+| `cockroachdb.changefeed.sink.topic.prefix`   | ""       | Prefix for intermediate topic names, used verbatim: topics are `<prefix><database>.<schema>.<table>`. Include your own separator (e.g. `crdb.`). If empty, defaults to `<topic.prefix>.` |
+| `cockroachdb.changefeed.max.tables.per.changefeed` | 0  | Max tables per changefeed. `0` = all in one. Set positive to split large table sets across multiple changefeeds and avoid per-table coupling |
 | `cockroachdb.changefeed.sink.options`        | ""       | Additional sink options in key=value format   |
 | `cockroachdb.changefeed.resolved.interval`   | 10s      | Resolved timestamp interval                   |
 | `cockroachdb.changefeed.include.updated`     | false    | Include updated column information            |
@@ -360,8 +361,6 @@ COCKROACHDB_VERSION=v25.4.10 docker-compose -f src/test/scripts/docker-compose.y
 ```
 
 ## Known Limitations
-
-- **Single changefeed job**: The connector creates a single multi-table changefeed (`CREATE CHANGEFEED FOR table1, table2, ...`) and consumes all per-table Kafka topics concurrently in a single KafkaConsumer. This is the [recommended approach](https://www.cockroachlabs.com/docs/stable/create-and-configure-changefeeds#recommendations) to stay within CockroachDB's ~80 changefeed job limit per cluster.
 
 - **Kafka-only sink**: Only Kafka sinks are supported. Webhook, Pub/Sub, and cloud storage sinks are planned.
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -280,11 +280,14 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 8))
             .withWidth(Width.LONG)
             .withImportance(Importance.HIGH)
+            .withValidation(CockroachDBConnectorConfig::validateChangefeedSinkUri)
             .withDescription("The URI for the changefeed sink (required). Format depends on sink type: "
                     + "'kafka://host:port' for Kafka, "
                     + "'pubsub://project:topic' for Pub/Sub, "
                     + "'webhook://url' for Webhook, "
-                    + "'cloudstorage://bucket' for Cloud Storage.");
+                    + "'cloudstorage://bucket' for Cloud Storage. "
+                    + "Do not set the topic_name or topic_prefix query parameters here; the connector manages "
+                    + "intermediate topic naming through cockroachdb.changefeed.sink.topic.prefix.");
 
     public static final Field CHANGEFEED_SINK_TOPIC_PREFIX = Field.create("cockroachdb.changefeed.sink.topic.prefix")
             .withDisplayName("Changefeed sink topic prefix")
@@ -293,9 +296,27 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withDefault("")
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
-            .withDescription("Prefix for changefeed topic names. Used to create topics in format: prefix.database.schema.table. " +
-                    "For multi-tenant deployments, consider using a unique prefix per tenant. " +
-                    "If not specified, defaults to the value of 'topic.prefix'.");
+            .withDescription("Prefix prepended to the intermediate changefeed topic names. The connector uses the value "
+                    + "verbatim, so the resulting topics are named <prefix><database>.<schema>.<table>. Include your own "
+                    + "separator if you want one (for example 'crdb.' yields 'crdb.mydb.public.orders', and 'env-prod-' "
+                    + "yields 'env-prod-mydb.public.orders'). If not specified, defaults to the value of 'topic.prefix' "
+                    + "followed by a dot.");
+
+    public static final Field CHANGEFEED_MAX_TABLES_PER_CHANGEFEED = Field.create("cockroachdb.changefeed.max.tables.per.changefeed")
+            .withDisplayName("Maximum tables per changefeed")
+            .withType(Type.INT)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED, 18))
+            .withDefault(0)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(Field::isNonNegativeInteger)
+            .withDescription("Maximum number of tables to include in a single CockroachDB changefeed. "
+                    + "The default of 0 places all configured tables in one changefeed. When set to a positive value, "
+                    + "the connector splits the captured tables into multiple changefeeds of at most this many tables "
+                    + "each, which avoids the performance coupling CockroachDB warns about when one changefeed watches "
+                    + "very many tables. Smaller values reduce coupling but create more changefeed jobs, so balance this "
+                    + "against CockroachDB's recommended limit on the number of changefeed jobs per cluster (see the "
+                    + "CockroachDB changefeed documentation for current guidance).");
 
     public static final Field CHANGEFEED_KAFKA_BOOTSTRAP_SERVERS = Field.create("cockroachdb.changefeed.kafka.bootstrap.servers")
             .withDisplayName("Kafka consumer bootstrap servers")
@@ -466,6 +487,7 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     CHANGEFEED_SINK_TYPE,
                     CHANGEFEED_SINK_URI,
                     CHANGEFEED_SINK_TOPIC_PREFIX,
+                    CHANGEFEED_MAX_TABLES_PER_CHANGEFEED,
                     CHANGEFEED_KAFKA_BOOTSTRAP_SERVERS,
                     CHANGEFEED_KAFKA_CONSUMER_GROUP_PREFIX,
                     CHANGEFEED_KAFKA_POLL_TIMEOUT_MS,
@@ -890,6 +912,28 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
         return 0;
     }
 
+    /**
+     * Rejects sink URIs that try to control topic naming directly. The connector manages the
+     * intermediate topic names itself (via {@code cockroachdb.changefeed.sink.topic.prefix} plus
+     * {@code full_table_name}) and subscribes its consumer to exactly those names. A user-supplied
+     * {@code topic_name} or {@code topic_prefix} in the sink URI would silently disagree with what
+     * the connector consumes and yield zero events, so we fail fast with guidance instead.
+     */
+    private static int validateChangefeedSinkUri(Configuration config, Field field, Field.ValidationOutput problems) {
+        String value = config.getString(field);
+        if (value == null) {
+            return 0;
+        }
+        String lower = value.toLowerCase();
+        if (lower.contains("topic_name=") || lower.contains("topic_prefix=")) {
+            problems.accept(field, value, "Do not set 'topic_name' or 'topic_prefix' in the sink URI. The connector "
+                    + "manages intermediate topic naming; use the 'cockroachdb.changefeed.sink.topic.prefix' property "
+                    + "(or 'topic.prefix') to control the topic prefix.");
+            return 1;
+        }
+        return 0;
+    }
+
     private static int validateOptionalReadableFile(Configuration config, Field field, Field.ValidationOutput problems) {
         String value = config.getString(field);
         if (value == null || value.isEmpty()) {
@@ -1024,6 +1068,10 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     public String getChangefeedSinkTopicPrefix() {
         return config.getString(CHANGEFEED_SINK_TOPIC_PREFIX);
+    }
+
+    public int getChangefeedMaxTablesPerChangefeed() {
+        return config.getInteger(CHANGEFEED_MAX_TABLES_PER_CHANGEFEED);
     }
 
     public String getChangefeedSinkOptions() {

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -52,8 +52,11 @@ import io.debezium.util.Metronome;
  * Kafka topic name, and dispatches events through Debezium's {@link EventDispatcher}
  * pipeline.</p>
  *
- * <p>CockroachDB recommends no more than ~80 changefeed jobs per cluster, so a
- * single multi-table changefeed is preferred over one changefeed per table.</p>
+ * <p>By default all configured tables are captured by a single multi-table changefeed, which
+ * keeps the connector to one changefeed job (CockroachDB recommends keeping the number of
+ * changefeed jobs per cluster modest). For large table counts,
+ * {@code cockroachdb.changefeed.max.tables.per.changefeed} splits the tables across several
+ * changefeeds to avoid CockroachDB's per-table performance coupling.</p>
  *
  * @author Virag Tripathi
  */
@@ -176,7 +179,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             }
 
             // Create a single multi-table changefeed (if not already running)
-            createMultiTableChangefeed(connection, tables, offsetContext, hasPriorOffset);
+            createChangefeeds(connection, tables, offsetContext, hasPriorOffset);
 
             // Consume events from all per-table topics in a single consumer
             consumeChangefeedEvents(tables, offsetContext, context);
@@ -199,28 +202,63 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * Creates a single multi-table changefeed covering all configured tables.
      * If a changefeed already exists for any of the tables, creation is skipped.
      */
-    private void createMultiTableChangefeed(
-                                            CockroachDBConnection connection,
-                                            List<TableId> tables,
-                                            CockroachDBOffsetContext offsetContext,
-                                            boolean hasPriorOffset)
+    /**
+     * Above this many tables in a single changefeed, the connector logs a recommendation to split
+     * the feed (see {@code cockroachdb.changefeed.max.tables.per.changefeed}). This is a connector
+     * heuristic to surface CockroachDB's coupling guidance, not a hard CockroachDB limit.
+     */
+    static final int SINGLE_CHANGEFEED_TABLE_WARN_THRESHOLD = 100;
+
+    /**
+     * Creates the changefeed(s) covering all configured tables. By default all tables go into a
+     * single changefeed; when {@code cockroachdb.changefeed.max.tables.per.changefeed} is positive,
+     * the tables are split into multiple changefeeds of at most that size to avoid CockroachDB's
+     * per-table performance coupling. A changefeed is skipped if one already covers its tables (for
+     * idempotent restarts and reuse of a pre-provisioned feed).
+     */
+    private void createChangefeeds(
+                                   CockroachDBConnection connection,
+                                   List<TableId> tables,
+                                   CockroachDBOffsetContext offsetContext,
+                                   boolean hasPriorOffset)
             throws SQLException {
 
-        // Check if a changefeed already covers any of our tables
-        for (TableId table : tables) {
-            if (changefeedExists(connection, table)) {
-                LOGGER.info("Changefeed already running for table {}, skipping multi-table creation", table);
-                return;
-            }
+        int maxPerChangefeed = config.getChangefeedMaxTablesPerChangefeed();
+        List<List<TableId>> groups = partitionTables(tables, maxPerChangefeed);
+
+        if (maxPerChangefeed <= 0 && tables.size() >= SINGLE_CHANGEFEED_TABLE_WARN_THRESHOLD) {
+            LOGGER.warn("Capturing {} tables in a single changefeed. CockroachDB's performance can become coupled "
+                    + "across many tables in one changefeed. Consider setting "
+                    + "cockroachdb.changefeed.max.tables.per.changefeed to split them into multiple changefeeds, "
+                    + "or run multiple connector instances each capturing a related subset of tables.", tables.size());
         }
 
-        String changefeedQuery = buildSinkChangefeedQuery(tables, offsetContext.getCursor(), hasPriorOffset);
-        LOGGER.info("Creating multi-table changefeed for {} table(s)", tables.size());
-        LOGGER.debug("Changefeed query: {}", changefeedQuery);
+        if (groups.size() > 1) {
+            LOGGER.info("Splitting {} table(s) into {} changefeed(s) (max {} tables each)",
+                    tables.size(), groups.size(), maxPerChangefeed);
+        }
 
-        try (Statement stmt = connection.connection().createStatement()) {
-            stmt.execute(changefeedQuery);
-            LOGGER.info("Created changefeed for tables: {}", tables);
+        for (List<TableId> group : groups) {
+            boolean alreadyRunning = false;
+            for (TableId table : group) {
+                if (changefeedExists(connection, table)) {
+                    alreadyRunning = true;
+                    break;
+                }
+            }
+            if (alreadyRunning) {
+                LOGGER.info("Changefeed already running for table(s) {}, skipping creation", group);
+                continue;
+            }
+
+            String changefeedQuery = buildSinkChangefeedQuery(group, offsetContext.getCursor(), hasPriorOffset);
+            LOGGER.info("Creating changefeed for {} table(s)", group.size());
+            LOGGER.debug("Changefeed query: {}", changefeedQuery);
+
+            try (Statement stmt = connection.connection().createStatement()) {
+                stmt.execute(changefeedQuery);
+                LOGGER.info("Created changefeed for tables: {}", group);
+            }
         }
 
         String initialScan = config.getInitialScanForSnapshotMode(hasPriorOffset);
@@ -229,6 +267,22 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             LOGGER.info("Initial scan in progress (snapshot.mode={})",
                     config.getSnapshotMode().getValue());
         }
+    }
+
+    /**
+     * Partitions the tables into changefeed groups. A {@code maxPerGroup} of 0 or less (the default)
+     * keeps every table in a single group, preserving the single-changefeed behavior. Otherwise the
+     * tables are split into consecutive chunks of at most {@code maxPerGroup}.
+     */
+    static List<List<TableId>> partitionTables(List<TableId> tables, int maxPerGroup) {
+        if (maxPerGroup <= 0 || tables.size() <= maxPerGroup) {
+            return List.of(new java.util.ArrayList<>(tables));
+        }
+        List<List<TableId>> groups = new java.util.ArrayList<>();
+        for (int i = 0; i < tables.size(); i += maxPerGroup) {
+            groups.add(new java.util.ArrayList<>(tables.subList(i, Math.min(i + maxPerGroup, tables.size()))));
+        }
+        return groups;
     }
 
     /**
@@ -260,11 +314,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      */
     private boolean changefeedExists(CockroachDBConnection connection, TableId table) throws SQLException {
         String fqTableName = sanitizeIdentifier(table.toString());
-        String topicPrefix = config.getChangefeedSinkTopicPrefix();
-        if (topicPrefix == null || topicPrefix.trim().isEmpty()) {
-            topicPrefix = config.getLogicalName();
-        }
-        String sinkMarker = "topic_prefix=" + topicPrefix + ".";
+        String topicPrefix = resolveTopicPrefix();
+        String sinkMarker = "topic_prefix=" + topicPrefix;
 
         try (Statement stmt = connection.connection().createStatement()) {
             String query = "SELECT description FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running'";
@@ -591,13 +642,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
 
         String sinkUri = config.getChangefeedSinkUri();
         sinkUri = injectSinkTlsParams(sinkUri);
-        String topicPrefix = config.getChangefeedSinkTopicPrefix();
-        if (topicPrefix == null || topicPrefix.trim().isEmpty()) {
-            topicPrefix = config.getLogicalName();
-        }
-        // Append topic_prefix to the sink URI so CockroachDB names topics as prefix.db.schema.table
+        // Use the resolved topic prefix verbatim so the user controls the separator. With
+        // full_table_name, CockroachDB names topics <prefix><database>.<schema>.<table>, which is
+        // exactly what buildTopicName subscribes to.
         String separator = sinkUri.contains("?") ? "&" : "?";
-        sinkUri = sinkUri + separator + "topic_prefix=" + sanitizeLiteral(topicPrefix) + ".";
+        sinkUri = sinkUri + separator + "topic_prefix=" + sanitizeLiteral(resolveTopicPrefix());
         query.append(" INTO '").append(sanitizeLiteral(sinkUri)).append("'");
 
         query.append(" WITH full_table_name");
@@ -641,16 +690,27 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
     }
 
     /**
-     * Builds the topic name for a table using the configured prefix and database name.
-     * Format: {@code {prefix}.{database}.{schema}.{table}}.
-     * Falls back to {@code topic.prefix} when no explicit sink topic prefix is configured.
+     * Resolves the intermediate-topic prefix. When the user sets
+     * {@code cockroachdb.changefeed.sink.topic.prefix}, it is used verbatim so the user controls the
+     * separator (for example {@code crdb.} or {@code env-prod-}). When it is not set, it defaults to
+     * {@code <topic.prefix>.} so the default topic layout remains
+     * {@code <topic.prefix>.<database>.<schema>.<table>}.
+     */
+    private String resolveTopicPrefix() {
+        String topicPrefix = config.getChangefeedSinkTopicPrefix();
+        if (topicPrefix != null && !topicPrefix.trim().isEmpty()) {
+            return topicPrefix;
+        }
+        return config.getLogicalName() + ".";
+    }
+
+    /**
+     * Builds the topic name for a table: {@code <prefix><database>.<schema>.<table>}, where the
+     * prefix already carries its own separator (see {@link #resolveTopicPrefix()}). This must match
+     * the topic that CockroachDB produces for {@code topic_prefix=<prefix>} with {@code full_table_name}.
      */
     private String buildTopicName(TableId table) {
-        String topicPrefix = config.getChangefeedSinkTopicPrefix();
-        if (topicPrefix == null || topicPrefix.trim().isEmpty()) {
-            topicPrefix = config.getLogicalName();
-        }
-        return topicPrefix + "." + config.getDatabaseName() + "." + table.schema() + "." + table.table();
+        return resolveTopicPrefix() + config.getDatabaseName() + "." + table.schema() + "." + table.table();
     }
 
     /**

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -454,6 +454,42 @@ public class CockroachDBConnectorConfigTest {
                 CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
     }
 
+    @Test
+    public void shouldRejectTopicNameInSinkUri() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092?topic_name=my_topic")
+                .build();
+        StringBuilder problemMessage = new StringBuilder();
+        boolean ok = config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                (String message) -> problemMessage.append(message));
+        assertThat(ok).isFalse();
+        assertThat(problemMessage.toString()).contains("topic_name");
+    }
+
+    @Test
+    public void shouldRejectTopicPrefixInSinkUri() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092?topic_prefix=foo")
+                .build();
+        StringBuilder problemMessage = new StringBuilder();
+        boolean ok = config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                (String message) -> problemMessage.append(message));
+        assertThat(ok).isFalse();
+        assertThat(problemMessage.toString()).contains("sink.topic.prefix");
+    }
+
+    @Test
+    public void shouldAcceptPlainSinkUri() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092")
+                .build();
+        assertThat(config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
+    }
+
     private static Configuration.Builder baseProps() {
         return Configuration.create()
                 .with("database.hostname", "localhost")

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
@@ -226,7 +226,9 @@ public class CockroachDBMultiTableTest {
     }
 
     @Test
-    public void shouldUseExplicitSinkTopicPrefixOverTopicPrefix() {
+    public void shouldUseExplicitSinkTopicPrefixVerbatim() {
+        // An explicitly set sink topic prefix is used verbatim (no separator is appended), so the
+        // user controls the separator. Here "custom" yields topic_prefix=custom (not custom.).
         Configuration config = Configuration.create()
                 .with("database.hostname", "localhost")
                 .with("database.port", "26257")
@@ -244,8 +246,32 @@ public class CockroachDBMultiTableTest {
 
         String query = source.buildSinkChangefeedQuery(tables, null, false);
 
-        assertThat(query).contains("topic_prefix=custom.");
-        assertThat(query).doesNotContain("topic_prefix=myapp.");
+        assertThat(query).contains("topic_prefix=custom");
+        assertThat(query).doesNotContain("topic_prefix=custom.");
+        assertThat(query).doesNotContain("myapp");
+    }
+
+    @Test
+    public void shouldUseSinkTopicPrefixWithCustomSeparatorVerbatim() {
+        // A prefix that carries its own separator (e.g. a dash convention) is preserved exactly,
+        // so the topic becomes <prefix><database>.<schema>.<table> with no connector-added dot.
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "bankdb")
+                .with("topic.prefix", "myapp")
+                .with("cockroachdb.changefeed.sink.topic.prefix", "env-prod-")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092")
+                .with("cockroachdb.changefeed.resolved.interval", "10s")
+                .build();
+
+        CockroachDBStreamingChangeEventSource source = createSource(config);
+        String query = source.buildSinkChangefeedQuery(
+                Collections.singletonList(new TableId("bankdb", "public", "orders")), null, false);
+
+        assertThat(query).contains("topic_prefix=env-prod-");
+        assertThat(query).doesNotContain("topic_prefix=env-prod-.");
     }
 
     @Test
@@ -415,5 +441,64 @@ public class CockroachDBMultiTableTest {
         return URLEncoder.encode(
                 Base64.getEncoder().encodeToString(content.getBytes(StandardCharsets.UTF_8)),
                 StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldKeepAllTablesInOneGroupWhenMaxIsZero() {
+        List<TableId> tables = List.of(
+                new TableId("db", "public", "t1"),
+                new TableId("db", "public", "t2"),
+                new TableId("db", "public", "t3"));
+
+        List<List<TableId>> groups = CockroachDBStreamingChangeEventSource.partitionTables(tables, 0);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0)).containsExactlyElementsOf(tables);
+    }
+
+    @Test
+    public void shouldKeepAllTablesInOneGroupWhenCountUnderMax() {
+        List<TableId> tables = List.of(
+                new TableId("db", "public", "t1"),
+                new TableId("db", "public", "t2"));
+
+        List<List<TableId>> groups = CockroachDBStreamingChangeEventSource.partitionTables(tables, 5);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0)).containsExactlyElementsOf(tables);
+    }
+
+    @Test
+    public void shouldSplitTablesIntoEvenChunks() {
+        List<TableId> tables = List.of(
+                new TableId("db", "public", "t1"),
+                new TableId("db", "public", "t2"),
+                new TableId("db", "public", "t3"),
+                new TableId("db", "public", "t4"));
+
+        List<List<TableId>> groups = CockroachDBStreamingChangeEventSource.partitionTables(tables, 2);
+
+        assertThat(groups).hasSize(2);
+        assertThat(groups.get(0)).hasSize(2);
+        assertThat(groups.get(1)).hasSize(2);
+    }
+
+    @Test
+    public void shouldSplitTablesWithRemainderChunk() {
+        List<TableId> tables = List.of(
+                new TableId("db", "public", "t1"),
+                new TableId("db", "public", "t2"),
+                new TableId("db", "public", "t3"),
+                new TableId("db", "public", "t4"),
+                new TableId("db", "public", "t5"));
+
+        List<List<TableId>> groups = CockroachDBStreamingChangeEventSource.partitionTables(tables, 2);
+
+        assertThat(groups).hasSize(3);
+        assertThat(groups.get(0)).hasSize(2);
+        assertThat(groups.get(1)).hasSize(2);
+        assertThat(groups.get(2)).hasSize(1);
+        // Every table is present exactly once across all groups.
+        assertThat(groups.stream().flatMap(List::stream)).containsExactlyElementsOf(tables);
     }
 }


### PR DESCRIPTION
Fixes debezium/dbz#2013
Fixes debezium/dbz#2014

## Summary

Two related improvements to how the connector names intermediate topics and creates changefeeds, from a user report about topic authorization.

### debezium/dbz#2013 — literal topic prefix, reject topic_name in sink URI (bug)

The connector forced a `.` after the topic prefix (`topic_prefix=<prefix>.`), so a prefix that already ended with a separator (for example `gmf-c2c-prf1-prpd-`) produced a doubled separator that failed topic authorization, and there was no way to control the separator. It also silently ignored a `topic_name`/`topic_prefix` set in the sink URI, producing zero events.

- `cockroachdb.changefeed.sink.topic.prefix` is now used **verbatim**: topics are `<prefix><database>.<schema>.<table>`, so the user controls the separator. When unset it defaults to `<topic.prefix>.`, preserving the existing default layout. The consumer's topic computation is updated to match (shared `resolveTopicPrefix()`).
- `topic_name`/`topic_prefix` in `cockroachdb.changefeed.sink.uri` is now rejected at config validation with guidance to use `cockroachdb.changefeed.sink.topic.prefix`.

The connector still does not honor CockroachDB's `topic_name` option, because it routes per table via `topic_prefix` + `full_table_name` whereas `topic_name` forces one topic for all tables. The literal prefix already reproduces any prefix-based naming a user needs.

### debezium/dbz#2014 — optional changefeed splitting for large table counts (enhancement)

The connector always created one changefeed for all tables. That is fine for a moderate, related set, but CockroachDB advises against one changefeed watching very many tables (performance coupling).

- Add `cockroachdb.changefeed.max.tables.per.changefeed` (default `0` = all in one, current behavior). When positive, the tables are split into multiple changefeeds of at most that size, with per-group reuse detection preserved. The consumer is unchanged (it already subscribes to all per-table topics).
- Warn when a single changefeed would cover a large number of tables and splitting is not configured.

## Changes

- `CockroachDBConnectorConfig`: sink-URI validator; literal `sink.topic.prefix` description; new `max.tables.per.changefeed` field
- `CockroachDBStreamingChangeEventSource`: `resolveTopicPrefix()`; literal prefix in changefeed URI and `buildTopicName`; `createChangefeeds()` with `partitionTables()` grouping and a high-table-count warning
- Unit tests: literal prefix (incl. custom separator), sink-URI rejection, table partitioning
- README updated; the multi-table changefeed item moves out of "Known Limitations" since it is now configurable

## Test plan

- [x] `mvn test` — 190 unit tests pass
- [x] `mvn verify -DskipUTs` — local IT suite passes (37 tests, 10 cloud-only skipped)
- [x] Cloud IT passes against a CockroachDB Cloud cluster with `sslmode=verify-full`

## Related

- Documentation updates ride along in debezium/debezium#7090