### PR TITLE
debezium/dbz#2023 Configure TLS/SASL for the changefeed consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Currently only the Kafka sink consumes these TLS parameters; other sink types pa
 | `cockroachdb.changefeed.kafka.consumer.group.prefix` | cockroachdb-connector | Kafka consumer group ID                                                                                                                                               |
 | `cockroachdb.changefeed.kafka.poll.timeout.ms`       | 100         | Kafka consumer poll timeout in milliseconds                                                                                                                                    |
 | `cockroachdb.changefeed.kafka.auto.offset.reset`     | earliest    | Kafka consumer auto offset reset policy                                                                                                                                        |
+| `cockroachdb.changefeed.kafka.consumer.override.*`   | -           | Passed verbatim to the changefeed consumer (Kafka client properties), e.g. `...override.security.protocol=SSL`. Use for SASL, custom trust/key stores, or to override auto-derived SSL. When `sink.tls.*` is set, the consumer's SSL is auto-derived from those PEM files, so this is only needed for extra or different settings. |
 
 #### Connection Settings
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.debezium.config.Configuration;
 import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.EventDispatcher;
@@ -387,6 +388,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, config.getChangefeedKafkaAutoOffsetReset());
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+
+        applyConsumerSecurity(config, props);
 
         LOGGER.debug("Kafka consumer config: bootstrapServers={}, groupId={}, autoOffsetReset={}, pollTimeout={}ms, topics={}",
                 props.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
@@ -771,6 +774,68 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         }
         catch (IOException e) {
             throw new IllegalStateException("Failed to read sink TLS file: " + filePath, e);
+        }
+    }
+
+    /**
+     * Prefix for properties passed verbatim to the connector's changefeed {@link KafkaConsumer}.
+     * Anything under {@code cockroachdb.changefeed.kafka.consumer.override.<kafka-property>} is applied
+     * directly to the consumer (for example {@code ...override.security.protocol=SSL}), following the
+     * same passthrough convention Debezium uses for its schema-history and signal Kafka clients. This
+     * is the escape hatch for SASL, custom trust/key stores, or overriding any auto-derived value.
+     */
+    static final String CONSUMER_OVERRIDE_PREFIX = "cockroachdb.changefeed.kafka.consumer.override.";
+
+    /**
+     * Configures security for the connector's changefeed consumer. The consumer is a normal Kafka
+     * client and is separate from the changefeed push to CockroachDB's Kafka sink, so it needs its
+     * own security settings to read from a secured broker.
+     *
+     * <p>Two layers, applied in order so the passthrough wins:
+     * <ol>
+     * <li>If {@code cockroachdb.changefeed.sink.tls.*} is set (the same PEM material used to push the
+     * changefeed over mTLS), derive {@code security.protocol=SSL} plus a PEM truststore (from the CA)
+     * and, when a client cert and key are present, a PEM keystore. This makes the mTLS round-trip work
+     * with no extra configuration.</li>
+     * <li>Apply every {@code cockroachdb.changefeed.kafka.consumer.override.*} property verbatim, which
+     * overrides the derived values and covers SASL, JKS stores, or a differently-secured broker.</li>
+     * </ol>
+     */
+    static void applyConsumerSecurity(CockroachDBConnectorConfig config, java.util.Properties props) {
+        if (config.isChangefeedSinkTlsEnabled()) {
+            props.put("security.protocol", "SSL");
+            String caCert = config.getChangefeedSinkTlsCaCertFile();
+            if (caCert != null && !caCert.isEmpty()) {
+                props.put("ssl.truststore.type", "PEM");
+                props.put("ssl.truststore.location", caCert);
+            }
+            String clientCert = config.getChangefeedSinkTlsClientCertFile();
+            String clientKey = config.getChangefeedSinkTlsClientKeyFile();
+            if (clientCert != null && !clientCert.isEmpty() && clientKey != null && !clientKey.isEmpty()) {
+                props.put("ssl.keystore.type", "PEM");
+                props.put("ssl.keystore.certificate.chain", readFileContent(clientCert));
+                props.put("ssl.keystore.key", readFileContent(clientKey));
+            }
+            LOGGER.info("Derived SSL config for the changefeed consumer from cockroachdb.changefeed.sink.tls.* (security.protocol=SSL)");
+        }
+
+        Configuration overrides = config.getConfig().subset(CONSUMER_OVERRIDE_PREFIX, true);
+        int applied = 0;
+        for (String key : overrides.keys()) {
+            props.put(key, overrides.getString(key));
+            applied++;
+        }
+        if (applied > 0) {
+            LOGGER.info("Applied {} '{}*' property/properties to the changefeed consumer", applied, CONSUMER_OVERRIDE_PREFIX);
+        }
+    }
+
+    private static String readFileContent(String filePath) {
+        try {
+            return new String(Files.readAllBytes(Path.of(filePath)), StandardCharsets.UTF_8);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("Failed to read sink TLS file for the changefeed consumer: " + filePath, e);
         }
     }
 

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConsumerSecurityTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConsumerSecurityTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.debezium.config.Configuration;
+
+/**
+ * Unit tests for the changefeed consumer's security configuration.
+ *
+ * <p>The connector's intermediate-topic consumer is a separate Kafka client from the changefeed
+ * push, so it needs its own security settings. These tests cover the two layers: auto-derived SSL
+ * from {@code cockroachdb.changefeed.sink.tls.*}, and the
+ * {@code cockroachdb.changefeed.kafka.consumer.override.*} passthrough.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBConsumerSecurityTest {
+
+    private static Configuration.Builder baseProps() {
+        return Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "defaultdb")
+                .with("database.server.name", "test-server")
+                .with("topic.prefix", "test")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9093");
+    }
+
+    private static Properties apply(Configuration config) {
+        Properties props = new Properties();
+        CockroachDBStreamingChangeEventSource.applyConsumerSecurity(new CockroachDBConnectorConfig(config), props);
+        return props;
+    }
+
+    @Test
+    public void shouldAddNoSecurityByDefault() {
+        Properties props = apply(baseProps().build());
+        assertThat(props.getProperty("security.protocol")).isNull();
+        assertThat(props).isEmpty();
+    }
+
+    @Test
+    public void shouldDeriveMutualTlsFromSinkTlsFiles(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.crt");
+        Path cert = tmp.resolve("client.crt");
+        Path key = tmp.resolve("client.key");
+        Files.writeString(ca, "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n");
+        Files.writeString(cert, "-----BEGIN CERTIFICATE-----\nCLIENT\n-----END CERTIFICATE-----\n");
+        Files.writeString(key, "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----\n");
+
+        Properties props = apply(baseProps()
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.cert.file", cert.toString())
+                .with("cockroachdb.changefeed.sink.tls.client.key.file", key.toString())
+                .build());
+
+        assertThat(props.getProperty("security.protocol")).isEqualTo("SSL");
+        assertThat(props.getProperty("ssl.truststore.type")).isEqualTo("PEM");
+        assertThat(props.getProperty("ssl.truststore.location")).isEqualTo(ca.toString());
+        assertThat(props.getProperty("ssl.keystore.type")).isEqualTo("PEM");
+        assertThat(props.getProperty("ssl.keystore.certificate.chain")).contains("CLIENT");
+        assertThat(props.getProperty("ssl.keystore.key")).contains("KEY");
+    }
+
+    @Test
+    public void shouldDeriveServerOnlyTlsFromCaOnly(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.crt");
+        Files.writeString(ca, "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n");
+
+        Properties props = apply(baseProps()
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .build());
+
+        assertThat(props.getProperty("security.protocol")).isEqualTo("SSL");
+        assertThat(props.getProperty("ssl.truststore.location")).isEqualTo(ca.toString());
+        // No client cert/key -> no keystore.
+        assertThat(props.getProperty("ssl.keystore.type")).isNull();
+    }
+
+    @Test
+    public void shouldApplyConsumerOverridePassthrough() {
+        Properties props = apply(baseProps()
+                .with("cockroachdb.changefeed.kafka.consumer.override.security.protocol", "SASL_SSL")
+                .with("cockroachdb.changefeed.kafka.consumer.override.sasl.mechanism", "SCRAM-SHA-512")
+                .build());
+
+        assertThat(props.getProperty("security.protocol")).isEqualTo("SASL_SSL");
+        assertThat(props.getProperty("sasl.mechanism")).isEqualTo("SCRAM-SHA-512");
+    }
+
+    @Test
+    public void shouldLetOverrideWinOverDerivedTls(@TempDir Path tmp) throws Exception {
+        Path ca = tmp.resolve("ca.crt");
+        Files.writeString(ca, "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n");
+
+        Properties props = apply(baseProps()
+                .with("cockroachdb.changefeed.sink.tls.ca.cert.file", ca.toString())
+                .with("cockroachdb.changefeed.kafka.consumer.override.security.protocol", "SASL_SSL")
+                .build());
+
+        // Auto-derive set SSL, but the explicit override wins.
+        assertThat(props.getProperty("security.protocol")).isEqualTo("SASL_SSL");
+    }
+
+    @Test
+    public void shouldNotTreatConsumerGroupPrefixAsPassthrough() {
+        // The existing cockroachdb.changefeed.kafka.consumer.group.prefix field must not leak into
+        // the consumer as a Kafka property via the override passthrough.
+        Properties props = apply(baseProps()
+                .with("cockroachdb.changefeed.kafka.consumer.group.prefix", "my-group")
+                .build());
+
+        assertThat(props.getProperty("group.prefix")).isNull();
+        assertThat(props).isEmpty();
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2023

## Summary

The connector has two Kafka interactions: CockroachDB pushing the changefeed to a Kafka sink (mTLS supported via debezium/dbz#1974), and the connector's own `KafkaConsumer` reading those intermediate topics back to produce the Debezium events. That consumer had no security configuration, so it always connected in plaintext. Against a secured broker (for example an mTLS listener on 9093) it was dropped during the handshake (`Cancelled in-flight API_VERSIONS request ... node disconnected`, `Bootstrap broker ... disconnected`) and no events flowed. There was no way to use the connector end to end against a fully secured Kafka cluster.

## Fix

Two layers, applied so the passthrough wins:

1. **Auto-derive from the sink TLS files.** When `cockroachdb.changefeed.sink.tls.*` is set (the same PEM material used to push the changefeed over mTLS), the consumer gets `security.protocol=SSL`, a PEM truststore from the CA, and, when a client cert and key are present, a PEM keystore. The mTLS round-trip works with no extra configuration.
2. **`cockroachdb.changefeed.kafka.consumer.override.*` passthrough.** Properties under this prefix are applied verbatim to the consumer, following the convention Debezium uses for its schema-history and signal Kafka clients (`config.subset(...)`). This covers SASL, JKS stores, a differently-secured broker, or overriding any auto-derived value. The prefix is collision-free with the existing `cockroachdb.changefeed.kafka.consumer.group.prefix` field.

## Changes

- `CockroachDBStreamingChangeEventSource`: `applyConsumerSecurity(config, props)` (auto-derive + passthrough), applied when building the changefeed consumer
- `CockroachDBConsumerSecurityTest` (6 tests): default no-security, derived mutual TLS, derived server-only TLS, override passthrough, override wins over derived, and the `consumer.group.prefix` non-collision
- README documents the new `consumer.override.*` passthrough

## Test plan

- [x] `mvn test` — 196 unit tests pass
- [x] `mvn verify -DskipUTs` — local IT suite passes (37 tests, 10 cloud-only skipped)
- [x] Cloud IT passes against a CockroachDB Cloud cluster with `sslmode=verify-full`
- [x] End-to-end: the `crdb-to-crdb-mtls` demo now has the connector consume over the mTLS listener (`kafka:9093`) using the auto-derived SSL config, and produces Debezium events with no plaintext workaround

## Related

- Documentation updates ride along in debezium/debezium#7090
- Strategic follow-up to remove the intermediate Kafka hop entirely: debezium/dbz#2024 (sinkless changefeeds)