### PR TITLE
debezium/dbz#2083 Fix temporal type handling: zoneless TIMESTAMP and Debezium logical type parity

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
@@ -7,6 +7,9 @@ package io.debezium.connector.cockroachdb;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -149,9 +152,18 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
                 return node.asText();
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
+                return parseTimestampMicros(node.asText());
             case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                return parseTimestampMicros(node.asText());
+                // ZonedTimestamp is a string; CockroachDB emits an ISO-8601 zoned value.
+                return node.asText();
+            case "TIME":
+            case "TIME WITHOUT TIME ZONE":
+                return parseTimeMicros(node.asText());
+            case "TIMETZ":
+            case "TIME WITH TIME ZONE":
+                // ZonedTime is a string; pass the CockroachDB value through.
+                return node.asText();
             case "DATE":
                 return parseDateDays(node.asText());
             default:
@@ -175,27 +187,59 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
 
     /**
      * Parses a CockroachDB timestamp string into microseconds since epoch.
-     * CockroachDB changefeed emits ISO-8601 strings like {@code "2026-02-19T19:06:58.916109Z"}.
-     * Debezium's {@code MicroTimestamp} schema expects {@code long} (microseconds since epoch).
+     *
+     * <p>CockroachDB emits {@code TIMESTAMPTZ} with a zone or trailing {@code 'Z'} (for example
+     * {@code "2026-02-19T19:06:58.916109Z"}), and {@code TIMESTAMP} (without time zone) with no zone
+     * at all (for example {@code "2026-06-08T11:01:45.883"}). Both are supported here. A zoneless
+     * {@code TIMESTAMP} is interpreted as UTC, matching Debezium's convention for timestamps without
+     * a time zone. Debezium's {@code MicroTimestamp} schema expects {@code long} microseconds since
+     * epoch.</p>
      */
-    private static Long parseTimestampMicros(String value) {
+    static Long parseTimestampMicros(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        // TIMESTAMPTZ with a trailing 'Z'.
+        try {
+            return toMicros(Instant.parse(value));
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // TIMESTAMPTZ with an explicit offset (for example +00:00).
+        try {
+            return toMicros(ZonedDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME).toInstant());
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // TIMESTAMP without time zone (no offset): interpret as UTC.
+        try {
+            return toMicros(LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+        }
+        catch (DateTimeParseException e) {
+            LOGGER.warn("Cannot parse timestamp '{}', returning null", value);
+            return null;
+        }
+    }
+
+    private static long toMicros(Instant instant) {
+        return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
+    }
+
+    /**
+     * Parses a CockroachDB TIME string into microseconds since midnight.
+     * CockroachDB emits TIME as {@code "HH:mm:ss[.ffffff]"}; Debezium's {@code MicroTime} schema
+     * expects {@code long} microseconds since midnight.
+     */
+    static Long parseTimeMicros(String value) {
         if (value == null || value.isEmpty()) {
             return null;
         }
         try {
-            Instant instant = Instant.parse(value);
-            return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
+            return LocalTime.parse(value, DateTimeFormatter.ISO_LOCAL_TIME).toNanoOfDay() / 1_000L;
         }
         catch (DateTimeParseException e) {
-            try {
-                ZonedDateTime zdt = ZonedDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME);
-                Instant instant = zdt.toInstant();
-                return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
-            }
-            catch (DateTimeParseException e2) {
-                LOGGER.warn("Cannot parse timestamp '{}', returning null", value);
-                return null;
-            }
+            LOGGER.warn("Cannot parse time '{}', returning null", value);
+            return null;
         }
     }
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
@@ -5,6 +5,14 @@
  */
 package io.debezium.connector.cockroachdb;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
 import org.apache.kafka.connect.data.Field;
@@ -18,6 +26,11 @@ import io.debezium.data.vector.DoubleVector;
 import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
 import io.debezium.relational.ValueConverterProvider;
+import io.debezium.time.Date;
+import io.debezium.time.MicroTime;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.ZonedTime;
+import io.debezium.time.ZonedTimestamp;
 
 /**
  * Value converter provider for CockroachDB.
@@ -99,23 +112,22 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             case "BLOB":
                 return SchemaBuilder.bytes().optional();
 
-            // Date/time types
+            // Date/time types -- schema names match the Debezium time logical types so downstream
+            // consumers (and the JDBC sink) interpret them the same as other Debezium connectors.
             case "DATE":
-                return SchemaBuilder.int32()
-                        .name("io.debezium.time.Date")
-                        .optional();
+                return Date.builder().optional();
             case "TIME":
-            case "TIMETZ":
             case "TIME WITHOUT TIME ZONE":
+                return MicroTime.builder().optional();
+            case "TIMETZ":
             case "TIME WITH TIME ZONE":
-                return SchemaBuilder.string().optional();
+                return ZonedTime.builder().optional();
             case "TIMESTAMP":
-            case "TIMESTAMPTZ":
             case "TIMESTAMP WITHOUT TIME ZONE":
+                return MicroTimestamp.builder().optional();
+            case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                return SchemaBuilder.int64()
-                        .name("io.debezium.time.MicroTimestamp")
-                        .optional();
+                return ZonedTimestamp.builder().optional();
             case "INTERVAL":
                 return SchemaBuilder.string().optional();
 
@@ -236,10 +248,9 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
                     return DoubleVector.fromLogical(schema, value.toString());
                 };
 
+            // TIMESTAMP without time zone -> MicroTimestamp (micros since epoch, interpreted as UTC).
             case "TIMESTAMP":
-            case "TIMESTAMPTZ":
             case "TIMESTAMP WITHOUT TIME ZONE":
-            case "TIMESTAMP WITH TIME ZONE":
                 return value -> {
                     if (value == null) {
                         return null;
@@ -249,20 +260,58 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
                     }
                     String ts = value.toString().trim();
                     try {
-                        java.time.Instant instant = java.time.Instant.parse(ts);
+                        Instant instant = Instant.parse(ts);
                         return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
                     }
-                    catch (java.time.format.DateTimeParseException e) {
+                    catch (DateTimeParseException e) {
                         try {
-                            java.time.ZonedDateTime zdt = java.time.ZonedDateTime.parse(ts, java.time.format.DateTimeFormatter.ISO_DATE_TIME);
-                            java.time.Instant inst = zdt.toInstant();
+                            ZonedDateTime zdt = ZonedDateTime.parse(ts, DateTimeFormatter.ISO_DATE_TIME);
+                            Instant inst = zdt.toInstant();
                             return inst.getEpochSecond() * 1_000_000L + inst.getNano() / 1_000L;
                         }
-                        catch (java.time.format.DateTimeParseException e2) {
-                            return null;
+                        catch (DateTimeParseException e2) {
+                            try {
+                                // TIMESTAMP without time zone (no offset): interpret as UTC.
+                                Instant inst = LocalDateTime.parse(ts, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                                        .toInstant(ZoneOffset.UTC);
+                                return inst.getEpochSecond() * 1_000_000L + inst.getNano() / 1_000L;
+                            }
+                            catch (DateTimeParseException e3) {
+                                return null;
+                            }
                         }
                     }
                 };
+
+            // TIMESTAMPTZ -> ZonedTimestamp (ISO-8601 string). CockroachDB already emits a zoned
+            // value (normalized to UTC), so pass it through.
+            case "TIMESTAMPTZ":
+            case "TIMESTAMP WITH TIME ZONE":
+                return value -> value == null ? null : value.toString();
+
+            // TIME without time zone -> MicroTime (micros since midnight).
+            case "TIME":
+            case "TIME WITHOUT TIME ZONE":
+                return value -> {
+                    if (value == null) {
+                        return null;
+                    }
+                    if (value instanceof Long) {
+                        return value;
+                    }
+                    try {
+                        return LocalTime.parse(value.toString().trim(), DateTimeFormatter.ISO_LOCAL_TIME)
+                                .toNanoOfDay() / 1_000L;
+                    }
+                    catch (DateTimeParseException e) {
+                        return null;
+                    }
+                };
+
+            // TIMETZ -> ZonedTime (string). Pass the CockroachDB value through.
+            case "TIMETZ":
+            case "TIME WITH TIME ZONE":
+                return value -> value == null ? null : value.toString();
 
             case "DATE":
                 return value -> {
@@ -273,9 +322,9 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
                         return value;
                     }
                     try {
-                        return (int) java.time.LocalDate.parse(value.toString().trim()).toEpochDay();
+                        return (int) LocalDate.parse(value.toString().trim()).toEpochDay();
                     }
-                    catch (java.time.format.DateTimeParseException e) {
+                    catch (DateTimeParseException e) {
                         return null;
                     }
                 };

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.relational.Column;
+
+/**
+ * Unit tests for {@link CockroachDBChangeRecordEmitter#parseTimestampMicros(String)}.
+ *
+ * <p>Covers both forms CockroachDB emits: {@code TIMESTAMPTZ} (with a trailing {@code Z} or an
+ * explicit offset) and {@code TIMESTAMP} without a time zone (no offset), which previously failed to
+ * parse and produced a null value, including for primary-key columns.</p>
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBChangeRecordEmitterTest {
+
+    @Test
+    public void shouldParseTimestampWithoutTimeZoneAsUtc() {
+        // TIMESTAMP (no zone): the format that regressed to null. Interpreted as UTC.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01.000"))
+                .isEqualTo(1_000_000L);
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.000001"))
+                .isEqualTo(1L);
+        // Microsecond precision is preserved (6 fractional digits).
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.123456"))
+                .isEqualTo(123_456L);
+        // No fractional seconds.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:02"))
+                .isEqualTo(2_000_000L);
+    }
+
+    @Test
+    public void shouldParseRealWorldTimestampWithoutTimeZone() {
+        // The exact format from the field report (TIMESTAMP primary key) must not be null.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("2026-06-08T11:01:45.883"))
+                .isNotNull();
+    }
+
+    @Test
+    public void shouldParseTimestampTzWithTrailingZ() {
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01Z"))
+                .isEqualTo(1_000_000L);
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.916109Z"))
+                .isEqualTo(916_109L);
+    }
+
+    @Test
+    public void shouldParseTimestampTzWithExplicitOffset() {
+        // 00:00:01 at +00:00 is epoch+1s; at +01:00 it is one hour earlier in UTC.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01+00:00"))
+                .isEqualTo(1_000_000L);
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T01:00:01+01:00"))
+                .isEqualTo(1_000_000L);
+    }
+
+    @Test
+    public void shouldReturnNullForNullEmptyOrUnparseable() {
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros(null)).isNull();
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("")).isNull();
+        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("not-a-timestamp")).isNull();
+    }
+
+    @Test
+    public void shouldExtractTemporalColumnValuesWithCorrectJavaTypes() throws Exception {
+        // Real CockroachDB enriched changefeed output for each temporal type (captured from v25.4.10).
+        String json = "{\"d\":\"2026-06-08\",\"id\":1,\"tm\":\"11:01:45.883\",\"tmtz\":\"11:01:45.883+02\","
+                + "\"ts\":\"2026-06-08T11:01:45.883\",\"tstz\":\"2026-06-08T09:01:45.883Z\"}";
+        JsonNode node = new ObjectMapper().readTree(json);
+        List<Column> columns = List.of(
+                Column.editor().name("ts").type("TIMESTAMP").create(),
+                Column.editor().name("tstz").type("TIMESTAMPTZ").create(),
+                Column.editor().name("tm").type("TIME").create(),
+                Column.editor().name("tmtz").type("TIMETZ").create(),
+                Column.editor().name("d").type("DATE").create());
+
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(node, columns);
+
+        // TIMESTAMP (without tz) -> MicroTimestamp (Long micros); must not be null (the original bug).
+        assertThat(values[0]).isInstanceOf(Long.class);
+        // TIMESTAMPTZ -> ZonedTimestamp (String, passed through).
+        assertThat(values[1]).isEqualTo("2026-06-08T09:01:45.883Z");
+        // TIME -> MicroTime (Long micros since midnight).
+        assertThat(values[2]).isEqualTo(39_705_883_000L);
+        // TIMETZ -> ZonedTime (String, short "+02" offset carried through).
+        assertThat(values[3]).isEqualTo("11:01:45.883+02");
+        // DATE -> Date (Integer days since epoch).
+        assertThat(values[4]).isInstanceOf(Integer.class);
+    }
+
+    @Test
+    public void shouldParseTimeToMicrosSinceMidnight() {
+        // CockroachDB emits TIME as "HH:mm:ss[.ffffff]"; MicroTime is micros since midnight.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("00:00:01")).isEqualTo(1_000_000L);
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("00:00:00.000001")).isEqualTo(1L);
+        // 11:01:45.883 = (11*3600 + 1*60 + 45)s + 0.883s = 39705.883s.
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("11:01:45.883")).isEqualTo(39_705_883_000L);
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros(null)).isNull();
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("")).isNull();
+        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("nope")).isNull();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
@@ -104,10 +104,23 @@ public class CockroachDBValueConverterProviderTest {
     }
 
     @Test
-    void timestamptzColumnReturnsMicroTimestamp() {
-        Column col = column("TIMESTAMPTZ");
-        SchemaBuilder builder = provider.schemaBuilder(col);
-        assertThat(builder.build().name()).isEqualTo("io.debezium.time.MicroTimestamp");
+    void temporalColumnsReturnDebeziumLogicalSchemas() {
+        // Schema names must match the Debezium time logical types (parity with other connectors).
+        assertThat(provider.schemaBuilder(column("TIMESTAMP")).build().name())
+                .isEqualTo("io.debezium.time.MicroTimestamp");
+        assertThat(provider.schemaBuilder(column("TIMESTAMPTZ")).build().name())
+                .isEqualTo("io.debezium.time.ZonedTimestamp");
+        assertThat(provider.schemaBuilder(column("TIME")).build().name())
+                .isEqualTo("io.debezium.time.MicroTime");
+        assertThat(provider.schemaBuilder(column("TIMETZ")).build().name())
+                .isEqualTo("io.debezium.time.ZonedTime");
+        assertThat(provider.schemaBuilder(column("DATE")).build().name())
+                .isEqualTo("io.debezium.time.Date");
+        // TIMESTAMPTZ/TIMETZ are strings; TIMESTAMP/TIME are int64.
+        assertThat(provider.schemaBuilder(column("TIMESTAMPTZ")).build().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(provider.schemaBuilder(column("TIMETZ")).build().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(provider.schemaBuilder(column("TIMESTAMP")).build().type()).isEqualTo(Schema.Type.INT64);
+        assertThat(provider.schemaBuilder(column("TIME")).build().type()).isEqualTo(Schema.Type.INT64);
     }
 
     @Test
@@ -161,6 +174,52 @@ public class CockroachDBValueConverterProviderTest {
 
         assertThat(converter.convert("3.14")).isEqualTo(3.14);
         assertThat(converter.convert(null)).isNull();
+    }
+
+    @Test
+    void timestampConverterHandlesZonedAndZonelessStrings() {
+        Column col = column("TIMESTAMP");
+        Schema schema = provider.schemaBuilder(col).build();
+        Field field = new Field("ts", 0, schema);
+        ValueConverter converter = provider.converter(col, field);
+
+        // Already-parsed micros pass through unchanged.
+        assertThat(converter.convert(1_000_000L)).isEqualTo(1_000_000L);
+        // TIMESTAMP without time zone (the previously-failing case) is interpreted as UTC.
+        assertThat(converter.convert("1970-01-01T00:00:01.000")).isEqualTo(1_000_000L);
+        assertThat(converter.convert("2026-06-08T11:01:45.883")).isNotNull();
+        // TIMESTAMPTZ with a trailing Z still works.
+        assertThat(converter.convert("1970-01-01T00:00:01Z")).isEqualTo(1_000_000L);
+        assertThat(converter.convert(null)).isNull();
+        assertThat(converter.convert("not-a-timestamp")).isNull();
+    }
+
+    @Test
+    void timeConverterParsesToMicrosSinceMidnight() {
+        Column col = column("TIME");
+        Field field = new Field("tm", 0, provider.schemaBuilder(col).build());
+        ValueConverter converter = provider.converter(col, field);
+
+        assertThat(converter.convert("00:00:01")).isEqualTo(1_000_000L);
+        assertThat(converter.convert("00:00:00.000001")).isEqualTo(1L);
+        assertThat(converter.convert("11:01:45.883")).isNotNull();
+        assertThat(converter.convert(1_000_000L)).isEqualTo(1_000_000L);
+        assertThat(converter.convert(null)).isNull();
+        assertThat(converter.convert("not-a-time")).isNull();
+    }
+
+    @Test
+    void zonedTimestampAndZonedTimeConvertersPassThroughStrings() {
+        Column tstz = column("TIMESTAMPTZ");
+        ValueConverter tstzConv = provider.converter(tstz, new Field("tstz", 0, provider.schemaBuilder(tstz).build()));
+        assertThat(tstzConv.convert("2026-06-08T09:01:45.883Z")).isEqualTo("2026-06-08T09:01:45.883Z");
+        assertThat(tstzConv.convert(null)).isNull();
+
+        Column tmtz = column("TIMETZ");
+        ValueConverter tmtzConv = provider.converter(tmtz, new Field("tmtz", 0, provider.schemaBuilder(tmtz).build()));
+        // CockroachDB emits a short "+02" offset; ZonedTime carries it through as a string.
+        assertThat(tmtzConv.convert("11:01:45.883+02")).isEqualTo("11:01:45.883+02");
+        assertThat(tmtzConv.convert(null)).isNull();
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * End-to-end verification that CockroachDB temporal column types are emitted with the correct
+ * Debezium logical schema types and non-null values: {@code TIMESTAMP -> MicroTimestamp},
+ * {@code TIMESTAMPTZ -> ZonedTimestamp}, {@code TIME -> MicroTime}, {@code TIMETZ -> ZonedTime},
+ * {@code DATE -> Date}. Guards the temporal type contract for downstream sinks.
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBTemporalTypesIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBTemporalTypesIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String DATABASE_NAME = "temporal_testdb";
+    private static final String TABLE_NAME = "temporal_types";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+                Statement stmt = defaultConn.createStatement()) {
+            stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT PRIMARY KEY, "
+                    + "ts TIMESTAMP, "
+                    + "tstz TIMESTAMPTZ, "
+                    + "tm TIME, "
+                    + "tmtz TIMETZ, "
+                    + "d DATE"
+                    + ")");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldEmitTemporalTypesWithDebeziumLogicalSchemas() throws Exception {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "temporal-types-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "temporal-test");
+        config.put("topic.prefix", "temporal-test");
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.include.diff", "true");
+        config.put("cockroachdb.changefeed.resolved.interval", "5s");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("snapshot.mode", "no_data");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+                LOGGER.error("Task start failed: {}", e.getMessage(), e);
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        assertThat(started.await(30, TimeUnit.SECONDS)).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+
+        waitForRunningChangefeed(30);
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, "
+                    + "'2026-06-08 11:01:45.883', "
+                    + "'2026-06-08 11:01:45.883+02:00', "
+                    + "'11:01:45.883', "
+                    + "'11:01:45.883+02:00', "
+                    + "'2026-06-08')");
+        }
+
+        List<SourceRecord> records = new ArrayList<>();
+        Struct after = null;
+        for (int i = 0; i < 60 && after == null; i++) {
+            List<SourceRecord> polled = task.poll();
+            if (polled != null) {
+                records.addAll(polled);
+            }
+            for (SourceRecord record : records) {
+                if (record.value() instanceof Struct value && value.schema().field("after") != null) {
+                    Struct a = value.getStruct("after");
+                    if (a != null && a.get("ts") != null) {
+                        after = a;
+                        break;
+                    }
+                }
+            }
+            Thread.sleep(1000);
+        }
+
+        assertThat(after).as("Should receive a create record with the temporal row").isNotNull();
+        LOGGER.info("Temporal after-struct: {}", after);
+
+        // Schema names must be the Debezium time logical types.
+        assertThat(after.schema().field("ts").schema().name()).isEqualTo("io.debezium.time.MicroTimestamp");
+        assertThat(after.schema().field("tstz").schema().name()).isEqualTo("io.debezium.time.ZonedTimestamp");
+        assertThat(after.schema().field("tm").schema().name()).isEqualTo("io.debezium.time.MicroTime");
+        assertThat(after.schema().field("tmtz").schema().name()).isEqualTo("io.debezium.time.ZonedTime");
+        assertThat(after.schema().field("d").schema().name()).isEqualTo("io.debezium.time.Date");
+
+        // Values are populated with the right Java types (the original bug emitted null).
+        assertThat(after.get("ts")).isInstanceOf(Long.class);
+        assertThat(after.get("tstz")).isInstanceOf(String.class);
+        assertThat(after.get("tm")).isInstanceOf(Long.class);
+        assertThat(after.get("tmtz")).isInstanceOf(String.class);
+        assertThat(after.get("d")).isInstanceOf(Integer.class);
+    }
+
+    private void waitForRunningChangefeed(int maxSeconds) throws Exception {
+        for (int i = 0; i < maxSeconds; i++) {
+            try (Statement stmt = connection.createStatement();
+                    var rs = stmt.executeQuery(
+                            "SELECT count(*) FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running' AND description LIKE '%" + TABLE_NAME + "%'")) {
+                if (rs.next() && rs.getInt(1) > 0) {
+                    return;
+                }
+            }
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException("Connector did not start a running changefeed within " + maxSeconds + "s");
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes debezium/dbz#2083.

## Problem

A CockroachDB `TIMESTAMP` (without time zone) was emitted as **null**. The connector only parsed zoned timestamp values (a trailing `Z` or an explicit offset), but CockroachDB serializes a zoneless `TIMESTAMP` with no zone (for example `2026-06-08T11:01:45.883`), so it failed to parse and became null, including for primary-key columns (which nulls the record key).

## Changes

- Interpret a zoneless `TIMESTAMP` as UTC in the row-value paths (the change-record emitter and the value converter; the default-value converter already handled it).
- Align the temporal type mappings with the Debezium logical types used by the PostgreSQL and other connectors:
  - `TIMESTAMP` / `TIMESTAMP WITHOUT TIME ZONE` → `MicroTimestamp`
  - `TIMESTAMPTZ` / `TIMESTAMP WITH TIME ZONE` → `ZonedTimestamp`
  - `TIME` / `TIME WITHOUT TIME ZONE` → `MicroTime`
  - `TIMETZ` / `TIME WITH TIME ZONE` → `ZonedTime`
  - `DATE` → `Date` (unchanged)
- The schema builder, value converter, and emitter are kept consistent per type.

## Verification

- Unit tests for each path, using the exact strings CockroachDB emits.
- New `CockroachDBTemporalTypesIT` asserts the logical schema types and non-null values end to end against a real CockroachDB + Kafka.
