### PR TITLE
debezium/dbz#2147 Normalize zoned temporal values to offset-qualified strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,10 @@ The connector maps CockroachDB column types to Kafka Connect schema types:
 | `VARCHAR`, `TEXT`, `STRING`           | `STRING`                          |                                         |
 | `BYTEA`, `BYTES`                      | `BYTES`                           |                                         |
 | `DATE`                                | `io.debezium.time.Date`           | Days since epoch                        |
-| `TIMESTAMP`, `TIMESTAMPTZ`            | `io.debezium.time.MicroTimestamp` | Microseconds since epoch                |
+| `TIMESTAMP`                           | `io.debezium.time.MicroTimestamp` | Microseconds since epoch (UTC)          |
+| `TIMESTAMPTZ`                         | `io.debezium.time.ZonedTimestamp` | Offset-qualified ISO-8601 string        |
+| `TIME`                                | `io.debezium.time.MicroTime`      | Microseconds since midnight             |
+| `TIMETZ`                              | `io.debezium.time.ZonedTime`      | Offset-qualified ISO-8601 string        |
 | `JSON`, `JSONB`                       | `io.debezium.data.Json`           |                                         |
 | `UUID`                                | `io.debezium.data.Uuid`           |                                         |
 | `VECTOR`                              | `io.debezium.data.DoubleVector`   | pgvector-compatible (CockroachDB 24.2+) |
@@ -340,10 +343,10 @@ Run integration tests (requires Docker for Testcontainers):
 ./mvnw clean test -Dtest="*IT"
 ```
 
-Run against a specific CockroachDB version (default is v25.4.10):
+Run against a specific CockroachDB version (default is v25.4.11):
 
 ```bash
-./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.10
+./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.11
 ```
 
 Run CockroachDB Cloud connectivity tests (requires a Cloud instance):
@@ -358,7 +361,7 @@ The Cloud IT is guarded by `@EnabledIfEnvironmentVariable` and will be skipped i
 For docker-compose based testing with a specific version:
 
 ```bash
-COCKROACHDB_VERSION=v25.4.10 docker-compose -f src/test/scripts/docker-compose.yml up
+COCKROACHDB_VERSION=v25.4.11 docker-compose -f src/test/scripts/docker-compose.yml up
 ```
 
 ## Known Limitations

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
 
-        <cockroachdb.version>v25.4.10</cockroachdb.version>
+        <cockroachdb.version>v25.4.11</cockroachdb.version>
         <version.jmh>1.37</version.jmh>
     </properties>
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
@@ -5,13 +5,7 @@
  */
 package io.debezium.connector.cockroachdb;
 
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 
@@ -152,18 +146,18 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
                 return node.asText();
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
-                return parseTimestampMicros(node.asText());
+                return CockroachDBTemporalConversions.parseTimestampMicros(node.asText());
             case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                // ZonedTimestamp is a string; CockroachDB emits an ISO-8601 zoned value.
-                return node.asText();
+                // ZonedTimestamp is an offset-qualified string; normalize so it satisfies the type.
+                return CockroachDBTemporalConversions.normalizeZonedTimestamp(node.asText());
             case "TIME":
             case "TIME WITHOUT TIME ZONE":
-                return parseTimeMicros(node.asText());
+                return CockroachDBTemporalConversions.parseTimeMicros(node.asText());
             case "TIMETZ":
             case "TIME WITH TIME ZONE":
-                // ZonedTime is a string; pass the CockroachDB value through.
-                return node.asText();
+                // ZonedTime is an offset-qualified string; normalize so it satisfies the type.
+                return CockroachDBTemporalConversions.normalizeZonedTime(node.asText());
             case "DATE":
                 return parseDateDays(node.asText());
             default:
@@ -182,64 +176,6 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
                     // Objects, arrays -> JSON string representation
                     return node.toString();
                 }
-        }
-    }
-
-    /**
-     * Parses a CockroachDB timestamp string into microseconds since epoch.
-     *
-     * <p>CockroachDB emits {@code TIMESTAMPTZ} with a zone or trailing {@code 'Z'} (for example
-     * {@code "2026-02-19T19:06:58.916109Z"}), and {@code TIMESTAMP} (without time zone) with no zone
-     * at all (for example {@code "2026-06-08T11:01:45.883"}). Both are supported here. A zoneless
-     * {@code TIMESTAMP} is interpreted as UTC, matching Debezium's convention for timestamps without
-     * a time zone. Debezium's {@code MicroTimestamp} schema expects {@code long} microseconds since
-     * epoch.</p>
-     */
-    static Long parseTimestampMicros(String value) {
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-        // TIMESTAMPTZ with a trailing 'Z'.
-        try {
-            return toMicros(Instant.parse(value));
-        }
-        catch (DateTimeParseException ignored) {
-        }
-        // TIMESTAMPTZ with an explicit offset (for example +00:00).
-        try {
-            return toMicros(ZonedDateTime.parse(value, DateTimeFormatter.ISO_DATE_TIME).toInstant());
-        }
-        catch (DateTimeParseException ignored) {
-        }
-        // TIMESTAMP without time zone (no offset): interpret as UTC.
-        try {
-            return toMicros(LocalDateTime.parse(value, DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
-        }
-        catch (DateTimeParseException e) {
-            LOGGER.warn("Cannot parse timestamp '{}', returning null", value);
-            return null;
-        }
-    }
-
-    private static long toMicros(Instant instant) {
-        return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
-    }
-
-    /**
-     * Parses a CockroachDB TIME string into microseconds since midnight.
-     * CockroachDB emits TIME as {@code "HH:mm:ss[.ffffff]"}; Debezium's {@code MicroTime} schema
-     * expects {@code long} microseconds since midnight.
-     */
-    static Long parseTimeMicros(String value) {
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-        try {
-            return LocalTime.parse(value, DateTimeFormatter.ISO_LOCAL_TIME).toNanoOfDay() / 1_000L;
-        }
-        catch (DateTimeParseException e) {
-            LOGGER.warn("Cannot parse time '{}', returning null", value);
-            return null;
         }
     }
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverter.java
@@ -7,10 +7,6 @@ package io.debezium.connector.cockroachdb;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,10 +102,6 @@ public class CockroachDBDefaultValueConverter implements DefaultValueConverter {
         register("JSON", passthroughString);
         register("JSONB", passthroughString);
         register("INTERVAL", passthroughString);
-        register("TIME", passthroughString);
-        register("TIMETZ", passthroughString);
-        register("TIME WITHOUT TIME ZONE", passthroughString);
-        register("TIME WITH TIME ZONE", passthroughString);
         register("GEOGRAPHY", passthroughString);
         register("GEOMETRY", passthroughString);
         register("ENUM", passthroughString);
@@ -119,20 +111,26 @@ public class CockroachDBDefaultValueConverter implements DefaultValueConverter {
 
         register("DATE", (c, v) -> (int) LocalDate.parse(v).toEpochDay());
 
-        Mapper timestampMapper = (c, v) -> {
-            try {
-                OffsetDateTime odt = OffsetDateTime.parse(v, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-                return odt.toInstant().getEpochSecond() * 1_000_000L + odt.toInstant().getNano() / 1_000L;
-            }
-            catch (DateTimeParseException ignored) {
-                java.time.Instant instant = java.time.LocalDateTime.parse(v).toInstant(ZoneOffset.UTC);
-                return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
-            }
-        };
-        register("TIMESTAMP", timestampMapper);
-        register("TIMESTAMPTZ", timestampMapper);
-        register("TIMESTAMP WITHOUT TIME ZONE", timestampMapper);
-        register("TIMESTAMP WITH TIME ZONE", timestampMapper);
+        // CockroachDB writes temporal defaults as SQL literals with a space separator (for example
+        // '2026-01-01 12:00:00') and an hour-only offset (for example '+00'). Reuse the shared
+        // conversions so the default value matches the schema type each temporal column maps to:
+        // TIMESTAMP -> MicroTimestamp (long), TIMESTAMPTZ -> ZonedTimestamp (string),
+        // TIME -> MicroTime (long), TIMETZ -> ZonedTime (string).
+        Mapper microTimestampMapper = (c, v) -> CockroachDBTemporalConversions.parseTimestampMicros(v.replace(' ', 'T'));
+        register("TIMESTAMP", microTimestampMapper);
+        register("TIMESTAMP WITHOUT TIME ZONE", microTimestampMapper);
+
+        Mapper zonedTimestampMapper = (c, v) -> CockroachDBTemporalConversions.normalizeZonedTimestamp(v.replace(' ', 'T'));
+        register("TIMESTAMPTZ", zonedTimestampMapper);
+        register("TIMESTAMP WITH TIME ZONE", zonedTimestampMapper);
+
+        Mapper microTimeMapper = (c, v) -> CockroachDBTemporalConversions.parseTimeMicros(v);
+        register("TIME", microTimeMapper);
+        register("TIME WITHOUT TIME ZONE", microTimeMapper);
+
+        Mapper zonedTimeMapper = (c, v) -> CockroachDBTemporalConversions.normalizeZonedTime(v);
+        register("TIMETZ", zonedTimeMapper);
+        register("TIME WITH TIME ZONE", zonedTimeMapper);
 
         register("BYTEA", (c, v) -> v.getBytes());
         register("BYTES", (c, v) -> v.getBytes());

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBTemporalConversions.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBTemporalConversions.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Conversions from the temporal strings CockroachDB emits into the wire shapes the Debezium time
+ * logical types require. Shared by the change-record emitter (streaming row values), the value
+ * converter (schema-typed values), and the default-value converter (column defaults), so all three
+ * agree on a single representation per type.
+ *
+ * <p>CockroachDB emits temporal values as JSON strings in an enriched changefeed, and as quoted SQL
+ * literals in column defaults. The relevant shapes are:</p>
+ *
+ * <ul>
+ *   <li>{@code TIMESTAMP} (no zone): {@code 2026-06-15T14:36:34.873} -> {@link io.debezium.time.MicroTimestamp}
+ *       (microseconds since epoch, interpreted as UTC).</li>
+ *   <li>{@code TIMESTAMPTZ}: {@code 2026-06-15T14:36:34.873Z} -> {@link io.debezium.time.ZonedTimestamp}
+ *       (ISO-8601 string with an offset).</li>
+ *   <li>{@code TIME} (no zone): {@code 14:36:34.873} -> {@link io.debezium.time.MicroTime}
+ *       (microseconds since midnight).</li>
+ *   <li>{@code TIMETZ}: {@code 14:36:34.873+00} -> {@link io.debezium.time.ZonedTime}
+ *       (ISO-8601 string with an offset).</li>
+ * </ul>
+ *
+ * <p>The zoned types are the subtle ones. {@code ZonedTimestamp} parses with
+ * {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME} and {@code ZonedTime} with
+ * {@link DateTimeFormatter#ISO_OFFSET_TIME}; both require an offset. CockroachDB writes the offset in
+ * the hour-only {@code +HH} form (for example {@code 14:36:34.873+00}), which those formatters reject,
+ * and a zoneless value can also reach the zoned path (for example an old row replayed after a column
+ * was altered between {@code TIMESTAMP} and {@code TIMESTAMPTZ}). Both cases are normalized here so the
+ * emitted string always satisfies the logical type, rather than passing the raw value straight through.</p>
+ *
+ * @author Virag Tripathi
+ */
+final class CockroachDBTemporalConversions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBTemporalConversions.class);
+
+    /**
+     * Parses an ISO-8601 timestamp whose offset is the hour-only {@code +HH} form (or {@code Z}) that
+     * CockroachDB can emit. {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME} requires at least
+     * {@code +HH:MM}, so this covers the hour-only case before the UTC fallback.
+     */
+    private static final DateTimeFormatter HOUR_OFFSET_DATE_TIME = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffset("+HH", "Z")
+            .toFormatter();
+
+    /**
+     * Parses an ISO-8601 time whose offset is the hour-only {@code +HH} form (or {@code Z}). This is
+     * the common CockroachDB shape for {@code TIMETZ} (for example {@code 14:36:34.873+00}).
+     */
+    private static final DateTimeFormatter HOUR_OFFSET_TIME = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .appendOffset("+HH", "Z")
+            .toFormatter();
+
+    private CockroachDBTemporalConversions() {
+    }
+
+    /**
+     * Parses a CockroachDB timestamp string into microseconds since epoch for
+     * {@link io.debezium.time.MicroTimestamp}.
+     *
+     * <p>Handles {@code TIMESTAMPTZ} with a trailing {@code Z} or an explicit {@code +HH:MM} offset,
+     * and {@code TIMESTAMP} without a zone (interpreted as UTC, matching Debezium's convention for
+     * timestamps without a time zone). Returns {@code null} for null, empty, or unparseable input.</p>
+     */
+    static Long parseTimestampMicros(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        String v = value.trim();
+        // TIMESTAMPTZ with a trailing 'Z'.
+        try {
+            return toMicros(Instant.parse(v));
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // TIMESTAMPTZ with an explicit offset (for example +00:00).
+        try {
+            return toMicros(ZonedDateTime.parse(v, DateTimeFormatter.ISO_DATE_TIME).toInstant());
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // TIMESTAMP without time zone (no offset): interpret as UTC.
+        try {
+            return toMicros(LocalDateTime.parse(v, DateTimeFormatter.ISO_LOCAL_DATE_TIME).toInstant(ZoneOffset.UTC));
+        }
+        catch (DateTimeParseException e) {
+            LOGGER.warn("Cannot parse timestamp '{}', returning null", value);
+            return null;
+        }
+    }
+
+    /**
+     * Parses a CockroachDB {@code TIME} string ({@code HH:mm:ss[.ffffff]}) into microseconds since
+     * midnight for {@link io.debezium.time.MicroTime}. Returns {@code null} for null, empty, or
+     * unparseable input.
+     */
+    static Long parseTimeMicros(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        try {
+            return LocalTime.parse(value.trim(), DateTimeFormatter.ISO_LOCAL_TIME).toNanoOfDay() / 1_000L;
+        }
+        catch (DateTimeParseException e) {
+            LOGGER.warn("Cannot parse time '{}', returning null", value);
+            return null;
+        }
+    }
+
+    /**
+     * Normalizes a CockroachDB {@code TIMESTAMPTZ} value into an offset-qualified ISO-8601 string that
+     * satisfies {@link io.debezium.time.ZonedTimestamp} ({@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}).
+     * An hour-only {@code +HH} offset is widened to {@code +HH:MM}, and a zoneless value is interpreted
+     * as UTC. Returns {@code null} for null, empty, or unparseable input.
+     */
+    static String normalizeZonedTimestamp(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        String v = value.trim();
+        // Already offset-qualified (Z, +HH:MM, ...): canonicalize via the target formatter.
+        try {
+            return OffsetDateTime.parse(v, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // Hour-only offset (for example +00): widen to +HH:MM.
+        try {
+            return OffsetDateTime.parse(v, HOUR_OFFSET_DATE_TIME)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // Zoneless: interpret as UTC.
+        try {
+            return LocalDateTime.parse(v, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                    .atOffset(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        }
+        catch (DateTimeParseException e) {
+            LOGGER.warn("Cannot normalize timestamptz '{}', returning null", value);
+            return null;
+        }
+    }
+
+    /**
+     * Normalizes a CockroachDB {@code TIMETZ} value into an offset-qualified ISO-8601 string that
+     * satisfies {@link io.debezium.time.ZonedTime} ({@link DateTimeFormatter#ISO_OFFSET_TIME}). An
+     * hour-only {@code +HH} offset (the shape CockroachDB emits, for example {@code +00}) is widened to
+     * {@code +HH:MM}, and a zoneless value is interpreted as UTC. Returns {@code null} for null, empty,
+     * or unparseable input.
+     */
+    static String normalizeZonedTime(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        String v = value.trim();
+        // Already offset-qualified (Z, +HH:MM, ...): canonicalize via the target formatter.
+        try {
+            return OffsetTime.parse(v, DateTimeFormatter.ISO_OFFSET_TIME)
+                    .format(DateTimeFormatter.ISO_OFFSET_TIME);
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // Hour-only offset (for example +00): widen to +HH:MM.
+        try {
+            return OffsetTime.parse(v, HOUR_OFFSET_TIME)
+                    .format(DateTimeFormatter.ISO_OFFSET_TIME);
+        }
+        catch (DateTimeParseException ignored) {
+        }
+        // Zoneless: interpret as UTC.
+        try {
+            return LocalTime.parse(v, DateTimeFormatter.ISO_LOCAL_TIME)
+                    .atOffset(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ISO_OFFSET_TIME);
+        }
+        catch (DateTimeParseException e) {
+            LOGGER.warn("Cannot normalize timetz '{}', returning null", value);
+            return null;
+        }
+    }
+
+    private static long toMicros(Instant instant) {
+        return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
+    }
+}

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
@@ -5,13 +5,7 @@
  */
 package io.debezium.connector.cockroachdb;
 
-import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
@@ -252,66 +246,31 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
                 return value -> {
-                    if (value == null) {
-                        return null;
-                    }
-                    if (value instanceof Long) {
+                    if (value == null || value instanceof Long) {
                         return value;
                     }
-                    String ts = value.toString().trim();
-                    try {
-                        Instant instant = Instant.parse(ts);
-                        return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
-                    }
-                    catch (DateTimeParseException e) {
-                        try {
-                            ZonedDateTime zdt = ZonedDateTime.parse(ts, DateTimeFormatter.ISO_DATE_TIME);
-                            Instant inst = zdt.toInstant();
-                            return inst.getEpochSecond() * 1_000_000L + inst.getNano() / 1_000L;
-                        }
-                        catch (DateTimeParseException e2) {
-                            try {
-                                // TIMESTAMP without time zone (no offset): interpret as UTC.
-                                Instant inst = LocalDateTime.parse(ts, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                                        .toInstant(ZoneOffset.UTC);
-                                return inst.getEpochSecond() * 1_000_000L + inst.getNano() / 1_000L;
-                            }
-                            catch (DateTimeParseException e3) {
-                                return null;
-                            }
-                        }
-                    }
+                    return CockroachDBTemporalConversions.parseTimestampMicros(value.toString());
                 };
 
-            // TIMESTAMPTZ -> ZonedTimestamp (ISO-8601 string). CockroachDB already emits a zoned
-            // value (normalized to UTC), so pass it through.
+            // TIMESTAMPTZ -> ZonedTimestamp (offset-qualified ISO-8601 string).
             case "TIMESTAMPTZ":
             case "TIMESTAMP WITH TIME ZONE":
-                return value -> value == null ? null : value.toString();
+                return value -> value == null ? null : CockroachDBTemporalConversions.normalizeZonedTimestamp(value.toString());
 
             // TIME without time zone -> MicroTime (micros since midnight).
             case "TIME":
             case "TIME WITHOUT TIME ZONE":
                 return value -> {
-                    if (value == null) {
-                        return null;
-                    }
-                    if (value instanceof Long) {
+                    if (value == null || value instanceof Long) {
                         return value;
                     }
-                    try {
-                        return LocalTime.parse(value.toString().trim(), DateTimeFormatter.ISO_LOCAL_TIME)
-                                .toNanoOfDay() / 1_000L;
-                    }
-                    catch (DateTimeParseException e) {
-                        return null;
-                    }
+                    return CockroachDBTemporalConversions.parseTimeMicros(value.toString());
                 };
 
-            // TIMETZ -> ZonedTime (string). Pass the CockroachDB value through.
+            // TIMETZ -> ZonedTime (offset-qualified ISO-8601 string).
             case "TIMETZ":
             case "TIME WITH TIME ZONE":
-                return value -> value == null ? null : value.toString();
+                return value -> value == null ? null : CockroachDBTemporalConversions.normalizeZonedTime(value.toString());
 
             case "DATE":
                 return value -> {

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
@@ -17,65 +17,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.debezium.relational.Column;
 
 /**
- * Unit tests for {@link CockroachDBChangeRecordEmitter#parseTimestampMicros(String)}.
- *
- * <p>Covers both forms CockroachDB emits: {@code TIMESTAMPTZ} (with a trailing {@code Z} or an
- * explicit offset) and {@code TIMESTAMP} without a time zone (no offset), which previously failed to
- * parse and produced a null value, including for primary-key columns.</p>
+ * Unit tests for {@link CockroachDBChangeRecordEmitter#extractColumnValues(JsonNode, List)}, the
+ * mapping from an enriched changefeed row to Java values aligned with the column schema types.
+ * Temporal value/normalization rules are covered by {@link CockroachDBTemporalConversionsTest}.
  *
  * @author Virag Tripathi
  */
 public class CockroachDBChangeRecordEmitterTest {
 
     @Test
-    public void shouldParseTimestampWithoutTimeZoneAsUtc() {
-        // TIMESTAMP (no zone): the format that regressed to null. Interpreted as UTC.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01.000"))
-                .isEqualTo(1_000_000L);
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.000001"))
-                .isEqualTo(1L);
-        // Microsecond precision is preserved (6 fractional digits).
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.123456"))
-                .isEqualTo(123_456L);
-        // No fractional seconds.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:02"))
-                .isEqualTo(2_000_000L);
-    }
-
-    @Test
-    public void shouldParseRealWorldTimestampWithoutTimeZone() {
-        // The exact format from the field report (TIMESTAMP primary key) must not be null.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("2026-06-08T11:01:45.883"))
-                .isNotNull();
-    }
-
-    @Test
-    public void shouldParseTimestampTzWithTrailingZ() {
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01Z"))
-                .isEqualTo(1_000_000L);
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:00.916109Z"))
-                .isEqualTo(916_109L);
-    }
-
-    @Test
-    public void shouldParseTimestampTzWithExplicitOffset() {
-        // 00:00:01 at +00:00 is epoch+1s; at +01:00 it is one hour earlier in UTC.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T00:00:01+00:00"))
-                .isEqualTo(1_000_000L);
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("1970-01-01T01:00:01+01:00"))
-                .isEqualTo(1_000_000L);
-    }
-
-    @Test
-    public void shouldReturnNullForNullEmptyOrUnparseable() {
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros(null)).isNull();
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("")).isNull();
-        assertThat(CockroachDBChangeRecordEmitter.parseTimestampMicros("not-a-timestamp")).isNull();
-    }
-
-    @Test
     public void shouldExtractTemporalColumnValuesWithCorrectJavaTypes() throws Exception {
-        // Real CockroachDB enriched changefeed output for each temporal type (captured from v25.4.10).
+        // Real CockroachDB enriched changefeed output for each temporal type (captured from v25.4.11).
         String json = "{\"d\":\"2026-06-08\",\"id\":1,\"tm\":\"11:01:45.883\",\"tmtz\":\"11:01:45.883+02\","
                 + "\"ts\":\"2026-06-08T11:01:45.883\",\"tstz\":\"2026-06-08T09:01:45.883Z\"}";
         JsonNode node = new ObjectMapper().readTree(json);
@@ -90,25 +42,28 @@ public class CockroachDBChangeRecordEmitterTest {
 
         // TIMESTAMP (without tz) -> MicroTimestamp (Long micros); must not be null (the original bug).
         assertThat(values[0]).isInstanceOf(Long.class);
-        // TIMESTAMPTZ -> ZonedTimestamp (String, passed through).
+        // TIMESTAMPTZ -> ZonedTimestamp (String); a Z value already satisfies ISO_OFFSET_DATE_TIME.
         assertThat(values[1]).isEqualTo("2026-06-08T09:01:45.883Z");
         // TIME -> MicroTime (Long micros since midnight).
         assertThat(values[2]).isEqualTo(39_705_883_000L);
-        // TIMETZ -> ZonedTime (String, short "+02" offset carried through).
-        assertThat(values[3]).isEqualTo("11:01:45.883+02");
+        // TIMETZ -> ZonedTime (String); the CockroachDB hour-only "+02" offset is normalized to
+        // "+02:00" so it parses with the ZonedTime (ISO_OFFSET_TIME) formatter downstream.
+        assertThat(values[3]).isEqualTo("11:01:45.883+02:00");
         // DATE -> Date (Integer days since epoch).
         assertThat(values[4]).isInstanceOf(Integer.class);
     }
 
     @Test
-    public void shouldParseTimeToMicrosSinceMidnight() {
-        // CockroachDB emits TIME as "HH:mm:ss[.ffffff]"; MicroTime is micros since midnight.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("00:00:01")).isEqualTo(1_000_000L);
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("00:00:00.000001")).isEqualTo(1L);
-        // 11:01:45.883 = (11*3600 + 1*60 + 45)s + 0.883s = 39705.883s.
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("11:01:45.883")).isEqualTo(39_705_883_000L);
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros(null)).isNull();
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("")).isNull();
-        assertThat(CockroachDBChangeRecordEmitter.parseTimeMicros("nope")).isNull();
+    public void shouldReturnNullForNullJsonColumnValues() throws Exception {
+        String json = "{\"id\":1,\"tstz\":null,\"tmtz\":null}";
+        JsonNode node = new ObjectMapper().readTree(json);
+        List<Column> columns = List.of(
+                Column.editor().name("tstz").type("TIMESTAMPTZ").create(),
+                Column.editor().name("tmtz").type("TIMETZ").create());
+
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(node, columns);
+
+        assertThat(values[0]).isNull();
+        assertThat(values[1]).isNull();
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDefaultValueConverterTest.java
@@ -95,6 +95,38 @@ public class CockroachDBDefaultValueConverterTest {
     }
 
     @Test
+    public void shouldParseTimestampDefaultAsMicros() {
+        // CockroachDB writes the literal with a space separator; it maps to MicroTimestamp (long).
+        Column col = column("TIMESTAMP");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'2026-01-01 12:00:00':::TIMESTAMP");
+        assertThat(parsed).isPresent().get().isInstanceOf(Long.class);
+    }
+
+    @Test
+    public void shouldParseTimestamptzDefaultAsOffsetQualifiedString() {
+        // The default must match the ZonedTimestamp (string) schema, with the hour-only offset widened.
+        Column col = column("TIMESTAMPTZ");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'2026-01-01 10:00:00+00':::TIMESTAMPTZ");
+        assertThat(parsed).isPresent().get().isInstanceOf(String.class).isEqualTo("2026-01-01T10:00:00Z");
+    }
+
+    @Test
+    public void shouldParseTimeDefaultAsMicrosSinceMidnight() {
+        // TIME maps to MicroTime (long), not a string. 12:34:56 = 45296s.
+        Column col = column("TIME");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'12:34:56':::TIME");
+        assertThat(parsed).isPresent().get().isInstanceOf(Long.class).isEqualTo(45_296_000_000L);
+    }
+
+    @Test
+    public void shouldParseTimetzDefaultAsOffsetQualifiedString() {
+        // TIMETZ maps to ZonedTime (string); the hour-only "+02" offset is widened to "+02:00".
+        Column col = column("TIMETZ");
+        Optional<Object> parsed = converter.parseDefaultValue(col, "'12:34:56+02':::TIMETZ");
+        assertThat(parsed).isPresent().get().isInstanceOf(String.class).isEqualTo("12:34:56+02:00");
+    }
+
+    @Test
     public void shouldReturnEmptyForUnknownType() {
         Column col = column("WIDGET");
         assertThat(converter.parseDefaultValue(col, "'foo'")).isEmpty();

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBTemporalConversionsTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBTemporalConversionsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link CockroachDBTemporalConversions}, covering the temporal strings CockroachDB
+ * emits (in both enriched changefeed JSON and SQL column defaults) against the Debezium time logical
+ * type contracts: {@code MicroTimestamp}/{@code MicroTime} (long) and {@code ZonedTimestamp}/
+ * {@code ZonedTime} (offset-qualified ISO-8601 string).
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBTemporalConversionsTest {
+
+    @Test
+    public void parseTimestampMicrosHandlesZonelessAsUtc() {
+        // TIMESTAMP without a zone: the format that previously regressed to null. Interpreted as UTC.
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:01.000")).isEqualTo(1_000_000L);
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:00.000001")).isEqualTo(1L);
+        // Microsecond precision preserved (6 fractional digits).
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:00.123456")).isEqualTo(123_456L);
+        // No fractional seconds.
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:02")).isEqualTo(2_000_000L);
+        // The exact field-reported value must not be null.
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("2026-06-08T11:01:45.883")).isNotNull();
+    }
+
+    @Test
+    public void parseTimestampMicrosHandlesZonedForms() {
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:01Z")).isEqualTo(1_000_000L);
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:00.916109Z")).isEqualTo(916_109L);
+        // Explicit offset: 01:00:01 at +01:00 is epoch+1s in UTC.
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T00:00:01+00:00")).isEqualTo(1_000_000L);
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("1970-01-01T01:00:01+01:00")).isEqualTo(1_000_000L);
+    }
+
+    @Test
+    public void parseTimestampMicrosReturnsNullForBadInput() {
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros(null)).isNull();
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("")).isNull();
+        assertThat(CockroachDBTemporalConversions.parseTimestampMicros("not-a-timestamp")).isNull();
+    }
+
+    @Test
+    public void parseTimeMicrosReturnsMicrosSinceMidnight() {
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros("00:00:01")).isEqualTo(1_000_000L);
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros("00:00:00.000001")).isEqualTo(1L);
+        // 11:01:45.883 = (11*3600 + 1*60 + 45)s + 0.883s = 39705.883s.
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros("11:01:45.883")).isEqualTo(39_705_883_000L);
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros(null)).isNull();
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros("")).isNull();
+        assertThat(CockroachDBTemporalConversions.parseTimeMicros("nope")).isNull();
+    }
+
+    @Test
+    public void normalizeZonedTimestampProducesOffsetQualifiedString() {
+        // A zoned value (trailing Z) already satisfies ISO_OFFSET_DATE_TIME and is kept.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873Z"))
+                .isEqualTo("2026-06-15T14:36:34.873Z");
+        // A zoneless value (for example an old row replayed under a TZ schema) is interpreted as UTC.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873"))
+                .isEqualTo("2026-06-15T14:36:34.873Z");
+        // An hour-only "+HH" offset is widened to "+HH:MM".
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873+05"))
+                .isEqualTo("2026-06-15T14:36:34.873+05:00");
+        // A zero hour-only offset normalizes to Z.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873+00"))
+                .isEqualTo("2026-06-15T14:36:34.873Z");
+        // A half-hour offset is preserved.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873+05:30"))
+                .isEqualTo("2026-06-15T14:36:34.873+05:30");
+        // Field-reported zoneless values with 2 and 3 fractional digits (the exact failing inputs).
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-07T00:16:01.07"))
+                .isEqualTo("2026-06-07T00:16:01.07Z");
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("2026-06-15T14:36:34.873"))
+                .isEqualTo("2026-06-15T14:36:34.873Z");
+    }
+
+    @Test
+    public void normalizeZonedTimestampOutputAlwaysParsesWithLogicalTypeFormatter() {
+        for (String in : new String[]{ "2026-06-15T14:36:34.873", "2026-06-15T14:36:34.873Z",
+                "2026-06-15T14:36:34.873+05", "2026-06-15T14:36:34.873+05:30", "2026-06-15T14:36:34-08" }) {
+            String out = CockroachDBTemporalConversions.normalizeZonedTimestamp(in);
+            assertThatNoException()
+                    .as("normalized '%s' -> '%s' must parse with ISO_OFFSET_DATE_TIME", in, out)
+                    .isThrownBy(() -> DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(out));
+        }
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp(null)).isNull();
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("")).isNull();
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTimestamp("not-a-timestamp")).isNull();
+    }
+
+    @Test
+    public void normalizeZonedTimeWidensHourOnlyOffset() {
+        // CockroachDB emits a TIMETZ offset as "+HH" (for example +02); normalize to "+HH:MM".
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("11:01:45.883+02"))
+                .isEqualTo("11:01:45.883+02:00");
+        // A zero hour-only offset normalizes to Z.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("14:36:34.873+00"))
+                .isEqualTo("14:36:34.873Z");
+        // A zoneless value is interpreted as UTC.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("14:36:34.873"))
+                .isEqualTo("14:36:34.873Z");
+        // A half-hour offset is preserved.
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("11:01:45.883+05:30"))
+                .isEqualTo("11:01:45.883+05:30");
+    }
+
+    @Test
+    public void normalizeZonedTimeOutputAlwaysParsesWithLogicalTypeFormatter() {
+        for (String in : new String[]{ "11:01:45.883", "14:36:34.873+00", "11:01:45.883+02",
+                "11:01:45.883+05:30", "11:01:45-08" }) {
+            String out = CockroachDBTemporalConversions.normalizeZonedTime(in);
+            assertThatNoException()
+                    .as("normalized '%s' -> '%s' must parse with ISO_OFFSET_TIME", in, out)
+                    .isThrownBy(() -> DateTimeFormatter.ISO_OFFSET_TIME.parse(out));
+        }
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime(null)).isNull();
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("")).isNull();
+        assertThat(CockroachDBTemporalConversions.normalizeZonedTime("not-a-time")).isNull();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
@@ -209,16 +209,19 @@ public class CockroachDBValueConverterProviderTest {
     }
 
     @Test
-    void zonedTimestampAndZonedTimeConvertersPassThroughStrings() {
+    void zonedTimestampAndZonedTimeConvertersNormalizeOffsets() {
         Column tstz = column("TIMESTAMPTZ");
         ValueConverter tstzConv = provider.converter(tstz, new Field("tstz", 0, provider.schemaBuilder(tstz).build()));
+        // A Z value already satisfies ISO_OFFSET_DATE_TIME and is kept.
         assertThat(tstzConv.convert("2026-06-08T09:01:45.883Z")).isEqualTo("2026-06-08T09:01:45.883Z");
+        // A zoneless value (old row replayed under a TZ schema) is interpreted as UTC.
+        assertThat(tstzConv.convert("2026-06-08T09:01:45.883")).isEqualTo("2026-06-08T09:01:45.883Z");
         assertThat(tstzConv.convert(null)).isNull();
 
         Column tmtz = column("TIMETZ");
         ValueConverter tmtzConv = provider.converter(tmtz, new Field("tmtz", 0, provider.schemaBuilder(tmtz).build()));
-        // CockroachDB emits a short "+02" offset; ZonedTime carries it through as a string.
-        assertThat(tmtzConv.convert("11:01:45.883+02")).isEqualTo("11:01:45.883+02");
+        // CockroachDB emits a short "+02" offset; ZonedTime requires "+02:00" downstream.
+        assertThat(tmtzConv.convert("11:01:45.883+02")).isEqualTo("11:01:45.883+02:00");
         assertThat(tmtzConv.convert(null)).isNull();
     }
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
@@ -35,7 +35,7 @@ import io.debezium.connector.cockroachdb.CockroachDBConnector;
 @Testcontainers
 public class CockroachDBConnectionIT {
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final Network NETWORK = Network.newNetwork();
 
     @Container

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
@@ -40,7 +40,7 @@ public class CockroachDBConnectorIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBConnectorIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "testdb";
     private static final String TABLE_NAME = "users";
     private static final String TOPIC_PREFIX = "test-cockroachdb";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
@@ -54,7 +54,7 @@ public class CockroachDBEndToEndIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBEndToEndIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "e2e_testdb";
     private static final String TABLE_NAME = "e2e_orders";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
@@ -49,7 +49,7 @@ public class CockroachDBHeartbeatIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBHeartbeatIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "heartbeat_testdb";
     private static final String TABLE_NAME = "hb_events";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBIncrementalSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBIncrementalSnapshotIT.java
@@ -59,7 +59,7 @@ public class CockroachDBIncrementalSnapshotIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBIncrementalSnapshotIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "inc_snap_testdb";
     private static final String TABLE_NAME = "snap_products";
     private static final String SIGNAL_TABLE = "debezium_signal";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
@@ -53,7 +53,7 @@ public class CockroachDBMultiTableIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBMultiTableIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "multi_table_testdb";
     private static final String ORDERS_TABLE = "mt_orders";
     private static final String CUSTOMERS_TABLE = "mt_customers";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
@@ -50,7 +50,7 @@ public class CockroachDBSchemaEvolutionIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSchemaEvolutionIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "schema_evo_testdb";
     private static final String TABLE_NAME = "evo_events";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
@@ -47,7 +47,7 @@ public class CockroachDBSnapshotIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSnapshotIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "snapshot_testdb";
     private static final String TABLE_NAME = "products";
     private static final String TOPIC_PREFIX = "snapshot-test";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
@@ -47,7 +47,7 @@ public class CockroachDBStreamingIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBStreamingIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "streaming_testdb";
     private static final String TABLE_NAME = "orders";
     private static final String TOPIC_PREFIX = "streaming-test";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
@@ -6,10 +6,12 @@
 package io.debezium.connector.cockroachdb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,7 +53,7 @@ public class CockroachDBTemporalTypesIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBTemporalTypesIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
     private static final String DATABASE_NAME = "temporal_testdb";
     private static final String TABLE_NAME = "temporal_types";
 
@@ -207,6 +209,18 @@ public class CockroachDBTemporalTypesIT {
         assertThat(after.get("tm")).isInstanceOf(Long.class);
         assertThat(after.get("tmtz")).isInstanceOf(String.class);
         assertThat(after.get("d")).isInstanceOf(Integer.class);
+
+        // The zoned strings must satisfy the logical-type formatters a downstream sink uses. This is
+        // the contract that the raw CockroachDB values violate: TIMESTAMPTZ arrives offset-qualified
+        // but TIMETZ arrives with an hour-only "+02" offset that ISO_OFFSET_TIME rejects.
+        String tstz = (String) after.get("tstz");
+        String tmtz = (String) after.get("tmtz");
+        assertThatNoException()
+                .as("tstz '%s' must parse as ZonedTimestamp (ISO_OFFSET_DATE_TIME)", tstz)
+                .isThrownBy(() -> DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(tstz));
+        assertThatNoException()
+                .as("tmtz '%s' must parse as ZonedTime (ISO_OFFSET_TIME)", tmtz)
+                .isThrownBy(() -> DateTimeFormatter.ISO_OFFSET_TIME.parse(tmtz));
     }
 
     private void waitForRunningChangefeed(int maxSeconds) throws Exception {

--- a/src/test/scripts/docker-compose.yml
+++ b/src/test/scripts/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
 
   cockroachdb:
-    image: cockroachdb/cockroach:${COCKROACHDB_VERSION:-v25.4.10}
+    image: cockroachdb/cockroach:${COCKROACHDB_VERSION:-v25.4.11}
     hostname: cockroachdb
     container_name: cockroachdb
     command: start-single-node --insecure


### PR DESCRIPTION
Closes debezium/dbz#2147.

## Problem

`TIMESTAMPTZ` and `TIMETZ` values were passed through unchanged. The Debezium `ZonedTimestamp` logical type parses with `ISO_OFFSET_DATE_TIME` and `ZonedTime` with `ISO_OFFSET_TIME`, both of which require an offset. CockroachDB emits a `TIMETZ` offset in the hour-only `+HH` form (for example `14:36:34.873+00`), which those formatters reject, and a zoneless value can reach the zoned path (for example an old row replayed after a column was altered between `TIMESTAMP` and `TIMESTAMPTZ`). A downstream Debezium JDBC sink then fails:

```
java.time.format.DateTimeParseException: Text '2026-06-15T14:36:34.873' could not be parsed at index 23
```

The default-value converter also produced values that did not match the post-dbz#2083 schema types (`TIMESTAMPTZ` as a long, `TIME` as a string), which fails schema build for a temporal column that has a default.

## Change

- Add `CockroachDBTemporalConversions` with the parse and normalize helpers shared by the change-record emitter, the value converter, and the default-value converter.
- Normalize `TIMESTAMPTZ` to `ZonedTimestamp` and `TIMETZ` to `ZonedTime` as offset-qualified ISO-8601 strings: an hour-only `+HH` offset is widened to `+HH:MM` and a zoneless value is interpreted as UTC.
- Align the default-value converter temporal mappers with the schema types (`TIMESTAMP`/`TIME` to long microseconds, `TIMESTAMPTZ`/`TIMETZ` to an offset-qualified string), handling the space-separated SQL literal CockroachDB stores.
- Correct the data-type table in the README.
- Pin CockroachDB `v25.4.11` for tests, ITs, and docker-compose.

## Verification

- Unit tests for `Z`, hour-only, `+HH:MM`, and zoneless inputs that assert the output parses with the logical-type formatter.
- `CockroachDBTemporalTypesIT` asserts the `tstz` and `tmtz` values parse with `ISO_OFFSET_DATE_TIME` and `ISO_OFFSET_TIME`.
- Full unit suite (213) and Testcontainers IT suite (38) pass.
- The `crdb-to-crdb` example replicates `TIMESTAMP`, `TIMESTAMPTZ`, `TIME`, `TIMETZ`, and `DATE` through the JDBC sink with no parse error.