### PR TITLE
debezium/dbz#2154 Resume the changefeed consumer from its persisted offset on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Currently only the Kafka sink consumes these TLS parameters; other sink types pa
 | `cockroachdb.changefeed.kafka.auto.offset.reset`     | earliest    | Kafka consumer auto offset reset policy                                                                                                                                        |
 | `cockroachdb.changefeed.kafka.consumer.override.*`   | -           | Passed verbatim to the changefeed consumer (Kafka client properties), e.g. `...override.security.protocol=SSL`. Use for SASL, custom trust/key stores, or to override auto-derived SSL. When `sink.tls.*` is set, the consumer's SSL is auto-derived from those PEM files, so this is only needed for extra or different settings. |
 
+The connector persists the position it has reached in each intermediate changefeed topic partition in its Debezium offset. On restart it resumes from that position rather than re-reading the topic from the beginning, so a restart does not re-emit the whole retained backlog. `auto.offset.reset` applies only on first start, when there is no stored position yet.
+
 #### Connection Settings
 
 | Option                                  | Default | Description                                 |

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContext.java
@@ -8,6 +8,7 @@ package io.debezium.connector.cockroachdb;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -40,30 +41,39 @@ public class CockroachDBOffsetContext extends CommonOffsetContext<SourceInfo> {
     public static final String CURSOR_INITIAL = "initial";
     public static final String CURSOR_NOW = "now";
 
+    /**
+     * Prefix for the intermediate consumer position persisted in the Debezium source offset. This is
+     * sink-agnostic: any delivery mode that consumes change events from an intermediate buffer (the
+     * kafka mode today, pubsub or cloudstorage in future) stores its resume position here under an
+     * opaque, sink-defined key. Persisting it in the source offset means Kafka Connect flushes it
+     * atomically with the cursor, only after the corresponding records are produced, so a restart can
+     * resume from the durable position instead of replaying the whole buffer. The sinkless mode does
+     * not use this; it resumes via the changefeed cursor and has no intermediate consumer.
+     */
+    public static final String CONSUMER_OFFSET_PREFIX = "consumer.offset.";
+
     private final SourceInfo sourceInfo;
 
     private String cursor;
     private Instant timestamp;
     private TransactionContext transactionContext;
     private final IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
-    private Long kafkaOffset;
+    private final Map<String, Long> consumerOffsets = new ConcurrentHashMap<>();
 
     public CockroachDBOffsetContext(CockroachDBConnectorConfig connectorConfig) {
         super(new SourceInfo(connectorConfig), false);
         this.sourceInfo = new SourceInfo(connectorConfig);
         this.cursor = connectorConfig.getChangefeedCursor();
         this.timestamp = Instant.now();
-        this.kafkaOffset = null;
         this.incrementalSnapshotContext = new SignalBasedIncrementalSnapshotContext<>(false);
     }
 
-    public CockroachDBOffsetContext(CockroachDBConnectorConfig config, String cursor, Instant timestamp, Long kafkaOffset,
+    public CockroachDBOffsetContext(CockroachDBConnectorConfig config, String cursor, Instant timestamp,
                                     IncrementalSnapshotContext<TableId> incrementalSnapshotContext) {
         super(new SourceInfo(config), false);
         this.sourceInfo = new SourceInfo(config);
         this.cursor = cursor;
         this.timestamp = timestamp;
-        this.kafkaOffset = kafkaOffset;
         this.incrementalSnapshotContext = incrementalSnapshotContext != null
                 ? incrementalSnapshotContext
                 : new SignalBasedIncrementalSnapshotContext<>(false);
@@ -91,7 +101,13 @@ public class CockroachDBOffsetContext extends CommonOffsetContext<SourceInfo> {
         Instant ts = timestamp != null ? timestamp : Instant.EPOCH;
         offset.put(TIMESTAMP, ts.toEpochMilli());
         offset.put(SNAPSHOT_COMPLETED_KEY, Boolean.toString(snapshotCompleted));
-        LOGGER.trace("Returning offset: cursor='{}', timestamp={}, snapshotCompleted={}", cursor, ts, snapshotCompleted);
+        // Persist the intermediate consumer position so a restart resumes instead of replaying the
+        // whole intermediate buffer from the beginning.
+        for (Map.Entry<String, Long> entry : consumerOffsets.entrySet()) {
+            offset.put(CONSUMER_OFFSET_PREFIX + entry.getKey(), entry.getValue());
+        }
+        LOGGER.trace("Returning offset: cursor='{}', timestamp={}, snapshotCompleted={}, consumerOffsets={}",
+                cursor, ts, snapshotCompleted, consumerOffsets);
         return offset;
     }
 
@@ -162,15 +178,29 @@ public class CockroachDBOffsetContext extends CommonOffsetContext<SourceInfo> {
             }
 
             CockroachDBOffsetContext context = new CockroachDBOffsetContext(
-                    connectorConfig, cursor, ts, null,
+                    connectorConfig, cursor, ts,
                     SignalBasedIncrementalSnapshotContext.load(offset, false));
 
             if (snapshot != null) {
                 context.snapshotCompleted = Boolean.parseBoolean(snapshot);
             }
 
-            LOGGER.debug("Loaded offset from storage: cursor='{}', timestamp={}, snapshotCompleted={}",
-                    context.getCursor(), context.getTimestamp(), context.snapshotCompleted);
+            // Restore the intermediate consumer positions so the consume path can resume from them
+            // on restart rather than replaying the buffer from the beginning.
+            for (Map.Entry<String, ?> entry : offset.entrySet()) {
+                if (entry.getKey().startsWith(CONSUMER_OFFSET_PREFIX) && entry.getValue() != null) {
+                    String key = entry.getKey().substring(CONSUMER_OFFSET_PREFIX.length());
+                    try {
+                        context.consumerOffsets.put(key, Long.parseLong(entry.getValue().toString()));
+                    }
+                    catch (NumberFormatException e) {
+                        LOGGER.warn("Invalid stored consumer offset '{}' for '{}', ignoring", entry.getValue(), key);
+                    }
+                }
+            }
+
+            LOGGER.debug("Loaded offset from storage: cursor='{}', timestamp={}, snapshotCompleted={}, consumerOffsets={}",
+                    context.getCursor(), context.getTimestamp(), context.snapshotCompleted, context.consumerOffsets);
             return context;
         }
     }
@@ -185,11 +215,21 @@ public class CockroachDBOffsetContext extends CommonOffsetContext<SourceInfo> {
         return this.cursor;
     }
 
-    public Long getKafkaOffset() {
-        return kafkaOffset;
+    /**
+     * Returns the last persisted intermediate consumer position for the given sink-defined key, or
+     * {@code null} if none is stored (for example on first start). For the kafka mode the key is
+     * {@code <topic>:<partition>}.
+     */
+    public Long getConsumerOffset(String key) {
+        return consumerOffsets.get(key);
     }
 
-    public void setKafkaOffset(Long kafkaOffset) {
-        this.kafkaOffset = kafkaOffset;
+    /**
+     * Records the intermediate consumer position for the given sink-defined key. This is included in
+     * {@link #getOffset()} and is flushed by Kafka Connect after the corresponding records are
+     * produced, so it marks a durable resume point that survives a restart.
+     */
+    public void setConsumerOffset(String key, long offset) {
+        consumerOffsets.put(key, offset);
     }
 }

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -15,6 +15,7 @@ import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -25,9 +26,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -399,7 +402,26 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 topicNames);
 
         try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
-            consumer.subscribe(topicNames);
+            // On (re)assignment, resume each partition from the position persisted in the Debezium
+            // offset. Without this the consumer never commits and resets to earliest on every restart,
+            // re-reading and re-emitting the entire retained changefeed topic (dbz#2154). Partitions
+            // with no stored position fall back to auto.offset.reset, preserving first-start behavior.
+            consumer.subscribe(topicNames, new ConsumerRebalanceListener() {
+                @Override
+                public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+                }
+
+                @Override
+                public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+                    for (TopicPartition tp : partitions) {
+                        Long stored = offsetContext.getConsumerOffset(kafkaConsumerOffsetKey(tp.topic(), tp.partition()));
+                        if (stored != null) {
+                            consumer.seek(tp, stored + 1);
+                            LOGGER.info("Resuming {} from stored offset {}", tp, stored + 1);
+                        }
+                    }
+                }
+            });
             LOGGER.info("Consuming from {} Kafka topic(s): {}", topicNames.size(), topicNames);
 
             Duration pollInterval = Duration.ofMillis(config.getChangefeedPollIntervalMs());
@@ -426,6 +448,9 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     if (!context.isRunning()) {
                         break;
                     }
+                    // Record the consumed position so it is persisted in the Debezium offset (flushed
+                    // by Connect after the dispatched events are produced) and a restart can resume here.
+                    offsetContext.setConsumerOffset(kafkaConsumerOffsetKey(record.topic(), record.partition()), record.offset());
                     String valueJson = record.value();
                     if (valueJson != null && !valueJson.trim().isEmpty()) {
                         TableId table = resolveTableFromTopic(record.topic());
@@ -454,6 +479,15 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             LOGGER.error("Error consuming from Kafka topics {}: {}", topicNames, e.getMessage(), e);
             throw new RuntimeException("Failed to consume from Kafka topics " + topicNames, e);
         }
+    }
+
+    /**
+     * Builds the sink-agnostic consumer-offset key for a Kafka topic partition, used to persist and
+     * resume the intermediate consumer position in the Debezium offset (see
+     * {@link CockroachDBOffsetContext#CONSUMER_OFFSET_PREFIX}).
+     */
+    static String kafkaConsumerOffsetKey(String topic, int partition) {
+        return topic + ":" + partition;
     }
 
     /**

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
@@ -80,7 +80,7 @@ public class CockroachDBIncrementalSnapshotTest {
         IncrementalSnapshotContext<TableId> snapContext = new SignalBasedIncrementalSnapshotContext<>(false);
 
         CockroachDBOffsetContext context = new CockroachDBOffsetContext(
-                config, "cursor", java.time.Instant.now(), null, snapContext);
+                config, "cursor", java.time.Instant.now(), snapContext);
         assertThat(context.getIncrementalSnapshotContext()).isSameAs(snapContext);
     }
 

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContextTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContextTest.java
@@ -73,11 +73,28 @@ public class CockroachDBOffsetContextTest {
     }
 
     @Test
-    public void shouldHandleKafkaOffsetOperations() {
-        Long testOffset = 12345L;
-        offsetContext.setKafkaOffset(testOffset);
+    public void shouldHandleConsumerOffsetOperations() {
+        String key = "offsetcommit-test.db.public.orders:0";
+        offsetContext.setConsumerOffset(key, 12345L);
 
-        assertThat(offsetContext.getKafkaOffset()).isEqualTo(testOffset);
+        assertThat(offsetContext.getConsumerOffset(key)).isEqualTo(12345L);
+        // The consumer offset is persisted in the source offset so a restart can resume from it.
+        assertThat(offsetContext.getOffset().get(CockroachDBOffsetContext.CONSUMER_OFFSET_PREFIX + key))
+                .isEqualTo(12345L);
+        // Unknown keys return null (first start for that partition).
+        assertThat(offsetContext.getConsumerOffset("unknown:9")).isNull();
+    }
+
+    @Test
+    public void shouldRoundTripConsumerOffsetThroughLoader() {
+        offsetContext.setConsumerOffset("topic-a:0", 100L);
+        offsetContext.setConsumerOffset("topic-a:1", 200L);
+
+        Map<String, ?> persisted = offsetContext.getOffset();
+        CockroachDBOffsetContext restored = new CockroachDBOffsetContext.Loader(config).load(persisted);
+
+        assertThat(restored.getConsumerOffset("topic-a:0")).isEqualTo(100L);
+        assertThat(restored.getConsumerOffset("topic-a:1")).isEqualTo(200L);
     }
 
     @Test
@@ -102,14 +119,12 @@ public class CockroachDBOffsetContextTest {
     public void shouldHandleConstructorWithCursorAndTimestamp() {
         String testCursor = "test-cursor";
         Instant testTimestamp = Instant.now();
-        Long testKafkaOffset = 67890L;
 
-        CockroachDBOffsetContext context = new CockroachDBOffsetContext(config, testCursor, testTimestamp, testKafkaOffset,
+        CockroachDBOffsetContext context = new CockroachDBOffsetContext(config, testCursor, testTimestamp,
                 new io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext<>(false));
         assertThat(context).isNotNull();
         assertThat(context.getCursor()).isEqualTo(testCursor);
         assertThat(context.getTimestamp()).isEqualTo(testTimestamp);
-        assertThat(context.getKafkaOffset()).isEqualTo(testKafkaOffset);
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRestartResumeIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRestartResumeIT.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * Regression test for dbz#2154: on restart the connector must resume the intermediate changefeed
+ * consumer from its persisted position instead of resetting to {@code earliest} and re-emitting the
+ * whole retained topic.
+ *
+ * <p>The test runs a task, captures the rows it emits and the source offset it would persist, then
+ * starts a second task seeded with that offset (simulating a Kafka Connect restart) and asserts the
+ * second task does not re-emit the already-processed rows. Before the fix the second task replays the
+ * entire topic; after the fix it resumes and emits nothing for the unchanged data.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBRestartResumeIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBRestartResumeIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String DATABASE_NAME = "restartresume_testdb";
+    private static final String TABLE_NAME = "restartresume_orders";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task1;
+    private CockroachDBConnectorTask task2;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+                Statement stmt = defaultConn.createStatement()) {
+            stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " (id INT PRIMARY KEY, name STRING)");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        for (CockroachDBConnectorTask t : new CockroachDBConnectorTask[]{ task1, task2 }) {
+            if (t != null) {
+                try {
+                    t.stop();
+                }
+                catch (Exception e) {
+                    LOGGER.warn("Error stopping task: {}", e.getMessage());
+                }
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldResumeFromPersistedOffsetInsteadOfReplayingOnRestart() throws Exception {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+        Map<String, String> config = baseConfig(hostBootstrap);
+
+        // Holds the offset the "previous run" persisted, fed back to the restarted task.
+        AtomicReference<Map<String, Object>> persistedOffset = new AtomicReference<>(null);
+
+        // --- Run 1: process the initial inserts and capture the offset that would be persisted. ---
+        task1 = new CockroachDBConnectorTask();
+        task1.initialize(contextReturning(persistedOffset));
+        startTask(task1, config);
+        waitForRunningChangefeed(30);
+
+        int rowCount = 5;
+        try (Statement stmt = connection.createStatement()) {
+            for (int i = 1; i <= rowCount; i++) {
+                stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (" + i + ", 'name-" + i + "')");
+            }
+        }
+
+        Set<Integer> firstRunIds = new HashSet<>();
+        for (int i = 0; i < 60 && firstRunIds.size() < rowCount; i++) {
+            for (SourceRecord r : poll(task1)) {
+                Integer id = createdId(r);
+                if (id != null) {
+                    firstRunIds.add(id);
+                }
+                // Capture the latest source offset; this is what Connect would persist and replay on restart.
+                @SuppressWarnings("unchecked")
+                Map<String, Object> off = (Map<String, Object>) r.sourceOffset();
+                if (off != null) {
+                    persistedOffset.set(new HashMap<>(off));
+                }
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(firstRunIds).as("Run 1 should emit all inserted rows").hasSize(rowCount);
+        assertThat(persistedOffset.get())
+                .as("Run 1 should persist a consumer position")
+                .isNotNull();
+        assertThat(persistedOffset.get().keySet().stream().anyMatch(k -> k.startsWith("consumer.offset.")))
+                .as("Persisted offset must contain the intermediate consumer position")
+                .isTrue();
+
+        task1.stop();
+        task1 = null;
+
+        // --- Run 2: restart seeded with the persisted offset, no new DML. Must not replay. ---
+        task2 = new CockroachDBConnectorTask();
+        task2.initialize(contextReturning(persistedOffset));
+        startTask(task2, config);
+
+        Set<Integer> secondRunIds = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            for (SourceRecord r : poll(task2)) {
+                Integer id = createdId(r);
+                if (id != null) {
+                    secondRunIds.add(id);
+                }
+            }
+            Thread.sleep(1000);
+        }
+
+        LOGGER.info("Run 2 re-emitted ids (should be empty): {}", secondRunIds);
+        assertThat(secondRunIds)
+                .as("After restart the connector must resume from the persisted offset and not replay processed rows")
+                .isEmpty();
+    }
+
+    private Map<String, String> baseConfig(String hostBootstrap) {
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "restartresume-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "restartresume-test");
+        config.put("topic.prefix", "restartresume-test");
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.resolved.interval", "5s");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("snapshot.mode", "no_data");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+        return config;
+    }
+
+    private void startTask(CockroachDBConnectorTask task, Map<String, String> config) throws Exception {
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread t = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+                LOGGER.error("Task start failed: {}", e.getMessage(), e);
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+        assertThat(started.await(30, TimeUnit.SECONDS)).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+    }
+
+    private static List<SourceRecord> poll(CockroachDBConnectorTask task) {
+        try {
+            List<SourceRecord> r = task.poll();
+            return r != null ? r : List.of();
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return List.of();
+        }
+    }
+
+    private static Integer createdId(SourceRecord record) {
+        if (record.value() instanceof Struct value && value.schema().field("after") != null) {
+            Struct after = value.getStruct("after");
+            if (after != null && after.schema().field("id") != null && after.get("id") != null) {
+                return ((Number) after.get("id")).intValue();
+            }
+        }
+        return null;
+    }
+
+    private void waitForRunningChangefeed(int maxSeconds) throws Exception {
+        for (int i = 0; i < maxSeconds; i++) {
+            try (Statement stmt = connection.createStatement();
+                    var rs = stmt.executeQuery(
+                            "SELECT count(*) FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running' AND description LIKE '%" + TABLE_NAME + "%'")) {
+                if (rs.next() && rs.getInt(1) > 0) {
+                    return;
+                }
+            }
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException("Connector did not start a running changefeed within " + maxSeconds + "s");
+    }
+
+    private SourceTaskContext contextReturning(AtomicReference<Map<String, Object>> persistedOffset) {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return persistedOffset.get();
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> partitions) {
+                        Map<Map<String, T>, Map<String, Object>> result = new HashMap<>();
+                        Map<String, Object> off = persistedOffset.get();
+                        if (off != null) {
+                            for (Map<String, T> p : partitions) {
+                                result.put(p, off);
+                            }
+                        }
+                        return result;
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes debezium/dbz#2154.

## Problem

In kafka mode the intermediate changefeed consumer has `enable.auto.commit=false` and never commits or seeks, while `auto.offset.reset` defaults to `earliest`. Because no position is ever persisted, every restart reset to `earliest` and re-read the entire retained changefeed topic, re-emitting the whole backlog. The in-memory dedup cache is empty after a restart and does not suppress the replay. The CockroachDB cursor in `connect-offsets` controls only what the changefeed emits, not what the consumer reads.

The downstream effect is duplicate amplification: each restart re-emits the retained backlog to the output topics, proportional to retention and restart count. Data stays correct with an idempotent sink, but reprocessing load and topic growth are not.

## Change

- Persist the intermediate consumer position in the Debezium source offset under a sink-agnostic key (`consumer.offset.<key>`), so Kafka Connect flushes it atomically with the cursor, only after the corresponding records are produced. This makes the position a durable, at-least-once-safe resume point with no data loss on crash, regardless of changefeed reuse.
- On (re)assignment the kafka consumer seeks each partition to its stored position (key `<topic>:<partition>`) instead of resetting to earliest; `auto.offset.reset` still applies on first start when no position is stored.
- The offset storage is generic so future consuming sinks (pubsub, cloudstorage) reuse it with their own key. The sinkless mode is unaffected; it resumes via the cursor and has no intermediate consumer.
- Document the restart-resume behavior in the README.

## Verification

- Unit tests persist and reload the per-key consumer offset through the offset `Loader`.
- `CockroachDBRestartResumeIT` drives inserts through one task, restarts a second task seeded with the persisted offset, and asserts the restart resumes without re-emitting the already-processed rows.
- Full unit suite and Testcontainers IT suite pass; the `crdb-to-crdb` example replicates end to end and a source connector restart does not replay the backlog (output topic offset unchanged).