### PR TITLE
debezium/dbz#2155 Drive the snapshot lifecycle and metrics for the changefeed initial scan

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeEventSourceFactory.java
@@ -38,6 +38,13 @@ public class CockroachDBChangeEventSourceFactory implements ChangeEventSourceFac
     private final CockroachDBSchema schema;
     private final Clock clock;
 
+    /**
+     * Captured from {@link #getSnapshotChangeEventSource} (the coordinator builds the snapshot source
+     * before the streaming source) and handed to the streaming source so it can drive the JMX
+     * snapshot metrics for the changefeed initial scan, which runs in the streaming path.
+     */
+    private volatile SnapshotProgressListener<CockroachDBPartition> snapshotProgressListener;
+
     public CockroachDBChangeEventSourceFactory(
                                                CockroachDBConnectorConfig config,
                                                EventDispatcher<CockroachDBPartition, TableId> dispatcher,
@@ -53,13 +60,14 @@ public class CockroachDBChangeEventSourceFactory implements ChangeEventSourceFac
     public SnapshotChangeEventSource<CockroachDBPartition, CockroachDBOffsetContext> getSnapshotChangeEventSource(
                                                                                                                   SnapshotProgressListener<CockroachDBPartition> snapshotProgressListener,
                                                                                                                   NotificationService<CockroachDBPartition, CockroachDBOffsetContext> notificationService) {
+        this.snapshotProgressListener = snapshotProgressListener;
         return new CockroachDBSnapshotChangeEventSource(config);
     }
 
     @Override
     public StreamingChangeEventSource<CockroachDBPartition, CockroachDBOffsetContext> getStreamingChangeEventSource() {
         LOGGER.debug("Creating CockroachDBStreamingChangeEventSource");
-        return new CockroachDBStreamingChangeEventSource(config, dispatcher, schema, clock);
+        return new CockroachDBStreamingChangeEventSource(config, dispatcher, schema, clock, snapshotProgressListener);
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -417,7 +417,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                         Long stored = offsetContext.getConsumerOffset(kafkaConsumerOffsetKey(tp.topic(), tp.partition()));
                         if (stored != null) {
                             consumer.seek(tp, stored + 1);
-                            LOGGER.info("Resuming {} from stored offset {}", tp, stored + 1);
+                            LOGGER.info("Resuming {}: last committed offset {}, seeking to next offset {}",
+                                    tp, stored, stored + 1);
                         }
                     }
                 }

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -39,9 +39,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
@@ -117,15 +119,23 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
 
     private volatile CockroachDBOffsetContext currentOffsetContext;
 
+    /**
+     * Drives the JMX snapshot metrics (SnapshotRunning/SnapshotCompleted) for the changefeed
+     * initial scan. May be null when the connector is constructed without a snapshot phase.
+     */
+    private final SnapshotProgressListener<CockroachDBPartition> snapshotProgressListener;
+
     public CockroachDBStreamingChangeEventSource(
                                                  CockroachDBConnectorConfig config,
                                                  EventDispatcher<CockroachDBPartition, TableId> dispatcher,
                                                  CockroachDBSchema schema,
-                                                 Clock clock) {
+                                                 Clock clock,
+                                                 SnapshotProgressListener<CockroachDBPartition> snapshotProgressListener) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         this.dispatcher = dispatcher;
         this.schema = schema;
         this.clock = clock;
+        this.snapshotProgressListener = snapshotProgressListener;
     }
 
     @Override
@@ -184,6 +194,24 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
 
             // Create a single multi-table changefeed (if not already running)
             createChangefeeds(connection, tables, offsetContext, hasPriorOffset);
+
+            // Drive the snapshot lifecycle for the changefeed initial scan so snapshot_completed,
+            // source.snapshot, and the JMX snapshot metrics reflect reality, matching the convention
+            // the PostgreSQL and other connectors follow. Completion is signalled on the first
+            // resolved timestamp (see processChangefeedEvent).
+            if (initialScanInProgress) {
+                offsetContext.markSnapshotRecord(SnapshotRecord.TRUE);
+                if (snapshotProgressListener != null) {
+                    snapshotProgressListener.snapshotStarted(partition);
+                }
+                LOGGER.info("Initial scan started for {} table(s)", tables.size());
+            }
+            else {
+                // No initial scan (snapshot.mode no_data/never, or restart with a prior cursor):
+                // there is nothing to backfill, so mark the snapshot already completed.
+                offsetContext.markSnapshotRecord(SnapshotRecord.FALSE);
+                offsetContext.preSnapshotCompletion();
+            }
 
             // Consume events from all per-table topics in a single consumer
             consumeChangefeedEvents(tables, offsetContext, context);
@@ -536,6 +564,18 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 if (initialScanInProgress) {
                     initialScanInProgress = false;
                     LOGGER.info("Initial scan completed (first resolved timestamp received: {})", resolvedTs);
+                    // The backfill is done: clear source.snapshot, mark snapshot_completed, and update
+                    // the JMX snapshot metrics so all snapshot surfaces agree (matching other connectors).
+                    offsetContext.markSnapshotRecord(SnapshotRecord.FALSE);
+                    offsetContext.preSnapshotCompletion();
+                    if (snapshotProgressListener != null && currentPartition != null) {
+                        try {
+                            snapshotProgressListener.snapshotCompleted(currentPartition);
+                        }
+                        catch (Exception e) {
+                            LOGGER.warn("Snapshot metrics completion notification failed: {}", e.getMessage());
+                        }
+                    }
                 }
 
                 // Update offset with the resolved timestamp so offsets advance

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
@@ -31,7 +31,7 @@ public class CockroachDBMultiTableTest {
 
     private CockroachDBStreamingChangeEventSource createSource(Configuration config) {
         CockroachDBConnectorConfig connectorConfig = new CockroachDBConnectorConfig(config);
-        return new CockroachDBStreamingChangeEventSource(connectorConfig, null, null, null);
+        return new CockroachDBStreamingChangeEventSource(connectorConfig, null, null, null, null);
     }
 
     private Configuration baseConfig() {

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContextTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContextTest.java
@@ -116,6 +116,21 @@ public class CockroachDBOffsetContextTest {
     }
 
     @Test
+    public void shouldMarkSnapshotCompletedInOffsetAndRoundTrip() {
+        // Before completion the flag is false (matches other connectors before the snapshot finishes).
+        assertThat(offsetContext.getOffset().get("snapshot_completed")).isEqualTo("false");
+
+        // Completing the snapshot sets the persisted flag to true.
+        offsetContext.preSnapshotCompletion();
+        assertThat(offsetContext.getOffset().get("snapshot_completed")).isEqualTo("true");
+
+        // The completed state survives a reload from the stored offset.
+        CockroachDBOffsetContext restored = new CockroachDBOffsetContext.Loader(config)
+                .load(offsetContext.getOffset());
+        assertThat(restored.getOffset().get("snapshot_completed")).isEqualTo("true");
+    }
+
+    @Test
     public void shouldHandleConstructorWithCursorAndTimestamp() {
         String testCursor = "test-cursor";
         Instant testTimestamp = Instant.now();

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotLifecycleIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotLifecycleIT.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * End-to-end verification of the snapshot lifecycle (dbz#2155). With {@code snapshot.mode=initial}
+ * the changefeed initial scan backfills existing rows; this asserts those backfill records carry
+ * {@code source.snapshot}, and that once the scan completes (first resolved timestamp) the offset
+ * reports {@code snapshot_completed=true} and steady-state records are not marked as snapshot.
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBSnapshotLifecycleIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSnapshotLifecycleIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String DATABASE_NAME = "snaplifecycle_testdb";
+    private static final String TABLE_NAME = "snaplifecycle_orders";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+                Statement stmt = defaultConn.createStatement()) {
+            stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " (id INT PRIMARY KEY, name STRING)");
+            // Seed rows BEFORE the connector starts so the initial scan backfills them.
+            for (int i = 1; i <= 3; i++) {
+                stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (" + i + ", 'seed-" + i + "')");
+            }
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldReportSnapshotLifecycleForInitialScan() throws Exception {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "snaplifecycle-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "snaplifecycle-test");
+        config.put("topic.prefix", "snaplifecycle-test");
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.resolved.interval", "5s");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("snapshot.mode", "initial");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+                LOGGER.error("Task start failed: {}", e.getMessage(), e);
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+        assertThat(started.await(30, TimeUnit.SECONDS)).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+
+        // Phase 1: collect the backfill reads (op=r) and confirm they are marked as snapshot records.
+        List<SourceRecord> all = new ArrayList<>();
+        boolean sawSnapshotRead = false;
+        for (int i = 0; i < 60 && !sawSnapshotRead; i++) {
+            List<SourceRecord> polled = task.poll();
+            if (polled != null) {
+                all.addAll(polled);
+            }
+            for (SourceRecord r : all) {
+                if ("r".equals(op(r)) && snapshot(r) != null && !"false".equals(snapshot(r))) {
+                    sawSnapshotRead = true;
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(sawSnapshotRead)
+                .as("Initial-scan backfill reads (op=r) must carry source.snapshot")
+                .isTrue();
+
+        // Phase 2: after the scan completes, new DML is a normal create that is not a snapshot record,
+        // and the offset reports snapshot_completed=true.
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (100, 'live')");
+        }
+
+        SourceRecord live = null;
+        for (int i = 0; i < 60 && live == null; i++) {
+            List<SourceRecord> polled = task.poll();
+            if (polled != null) {
+                for (SourceRecord r : polled) {
+                    if ("c".equals(op(r)) && after(r) != null && intId(after(r)) == 100) {
+                        live = r;
+                        break;
+                    }
+                }
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(live).as("Should receive the live create after the snapshot").isNotNull();
+        assertThat(snapshot(live))
+                .as("Steady-state records must not be marked as snapshot")
+                .satisfiesAnyOf(s -> assertThat(s).isNull(), s -> assertThat(s).isEqualTo("false"));
+        assertThat(String.valueOf(live.sourceOffset().get("snapshot_completed")))
+                .as("snapshot_completed must be true once the initial scan has finished")
+                .isEqualTo("true");
+    }
+
+    private static String op(SourceRecord r) {
+        if (r.value() instanceof Struct v && v.schema().field("op") != null) {
+            return v.getString("op");
+        }
+        return null;
+    }
+
+    private static Struct after(SourceRecord r) {
+        if (r.value() instanceof Struct v && v.schema().field("after") != null) {
+            return v.getStruct("after");
+        }
+        return null;
+    }
+
+    private static int intId(Struct after) {
+        return ((Number) after.get("id")).intValue();
+    }
+
+    private static String snapshot(SourceRecord r) {
+        if (r.value() instanceof Struct v && v.schema().field("source") != null) {
+            Struct source = v.getStruct("source");
+            if (source != null && source.schema().field("snapshot") != null && source.get("snapshot") != null) {
+                return String.valueOf(source.get("snapshot"));
+            }
+        }
+        return null;
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes debezium/dbz#2155.

Bundles two related observability changes.

## Snapshot lifecycle and metrics (dbz#2155)

The connector backfills via the CockroachDB changefeed `initial_scan` in the streaming path and returns a `skipped` framework snapshot, so the standard snapshot lifecycle was never driven. As a result, unlike the PostgreSQL and other connectors:

- the offset key `snapshot_completed` never became `true` (always `false` in `GET /connectors/<name>/offsets`),
- backfill reads (`op=r`) did not carry `source.snapshot`, and
- the JMX snapshot-metrics MBean (`SnapshotRunning`, `SnapshotCompleted`) was never updated, so Prometheus/Grafana could not observe snapshot progress.

This drives the standard lifecycle from the changefeed initial scan, matching the core convention:

- thread the `SnapshotProgressListener` into the streaming source via the factory;
- at scan start, mark snapshot records (`source.snapshot`) and call `snapshotStarted`;
- on the first resolved timestamp (scan complete), call `preSnapshotCompletion` (sets `snapshot_completed=true`), clear `source.snapshot`, and call `snapshotCompleted`;
- for modes with no initial scan and restarts with a prior cursor, mark the snapshot completed up front.

Streaming and queue metrics already flow through the standard `EventDispatcher` and `DefaultChangeEventSourceMetricsFactory` the connector uses, so all metrics are now populated under the standard MBean names (`debezium.cockroachdb:type=connector-metrics,context=snapshot|streaming,server=<topic.prefix>`).

## Resume log clarification (dbz#2154 follow-up)

The consumer resume log printed the seek position under a "stored offset" label; it now prints the last committed offset and the next offset being sought, so it lines up with the `consumer.offset` entries in the connector offsets.

## Verification

- Unit test for the `snapshot_completed` offset transition and reload.
- `CockroachDBSnapshotLifecycleIT` asserts backfill reads carry `source.snapshot`, `snapshot_completed` is `true` after the first resolved timestamp, and steady-state records are not marked as snapshot.
- Full unit suite (215) and Testcontainers IT suite (40 run, 10 cloud-skipped) pass.