### PR TITLE
debezium/dbz#1644 Enabled poll.dispatch.interval.ms config for ChangeEventQueue for batch processing.

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorTask.java
@@ -123,6 +123,7 @@ public class CockroachDBConnectorTask extends BaseSourceTask<CockroachDBPartitio
 
         this.queue = new ChangeEventQueue.Builder<DataChangeEvent>()
                 .pollInterval(connectorConfig.getPollInterval())
+                .pollDispatchInterval(connectorConfig.getPollDispatchInterval())
                 .maxBatchSize(connectorConfig.getMaxBatchSize())
                 .maxQueueSize(connectorConfig.getMaxQueueSize())
                 .maxQueueSizeInBytes(connectorConfig.getMaxQueueSizeInBytes())

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBErrorHandlerTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBErrorHandlerTest.java
@@ -10,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,8 @@ public class CockroachDBErrorHandlerTest {
                     .build()),
             new ChangeEventQueue.Builder<DataChangeEvent>()
                     .queueProvider(createDefaultQueueProvider(DEFAULT_MAX_QUEUE_SIZE))
+                    .pollInterval(Duration.ofMillis(500))
+                    .pollDispatchInterval(Duration.ofMillis(0))
                     .build(),
             null);
 


### PR DESCRIPTION
Fixes debezium/dbz#1644