### PR TITLE
[ci] Fetch all open pull requests when resolving the cross-repository branch

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -40,7 +40,9 @@ jobs:
         env:
           branch_name: ${{ github.head_ref }}
         run: |
-          curl --silent -X "GET" https://api.github.com/repos/debezium/debezium/pulls | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
+          for page in 1 2 3; do
+            curl --silent -X "GET" "https://api.github.com/repos/debezium/debezium/pulls?state=open&per_page=100&page=${page}" | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
+          done
 
           while IFS=" " read -r BRANCH;
           do


### PR DESCRIPTION
The cross-maven workflow resolves whether a pull request has a matching branch in the debezium main repository so the connector can be built against that branch. The pull request list was fetched without pagination parameters, so only the newest thirty pull requests were returned and older matching branches were not found, causing the build to run against the published snapshot instead. Reported in https://github.com/debezium/debezium-connector-cockroachdb/pull/53#issuecomment by @hagar-yasser1, whose paired debezium/debezium#7228 branch falls outside the first page of the currently 164 open pull requests.

Fetch up to three pages of one hundred open pull requests. Verified against the live API: the paginated fetch returns all 164 open pull request branches, including dbz#1644; the unpaginated fetch returns 30 and misses it.

The same unpaginated fetch exists in the cross-maven workflows of the other standalone connector repositories (spanner, informix, db2, vitess, ibmi, cassandra).