### PR TITLE
debezium/dbz#2256 Parse changefeed decimals as BigDecimal to preserve precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,10 +354,10 @@ Run integration tests (requires Docker for Testcontainers):
 ./mvnw clean test -Dtest="*IT"
 ```
 
-Run against a specific CockroachDB version (default is v25.4.11):
+Run against a specific CockroachDB version (default is v25.4.13):
 
 ```bash
-./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.11
+./mvnw clean test -Dtest="*IT" -Dcockroachdb.version=v25.4.13
 ```
 
 Run CockroachDB Cloud connectivity tests (requires a Cloud instance):
@@ -372,7 +372,7 @@ The Cloud IT is guarded by `@EnabledIfEnvironmentVariable` and will be skipped i
 For docker-compose based testing with a specific version:
 
 ```bash
-COCKROACHDB_VERSION=v25.4.11 docker-compose -f src/test/scripts/docker-compose.yml up
+COCKROACHDB_VERSION=v25.4.13 docker-compose -f src/test/scripts/docker-compose.yml up
 ```
 
 ## Known Limitations

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
 
-        <cockroachdb.version>v25.4.11</cockroachdb.version>
+        <cockroachdb.version>v25.4.13</cockroachdb.version>
         <version.jmh>1.37</version.jmh>
     </properties>
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
@@ -140,7 +140,9 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
                 return node.asDouble();
             case "NUMERIC":
             case "DECIMAL":
-                return node.asText();
+            case "DEC":
+                // Emit the exact source digits; toPlainString avoids scientific notation.
+                return node.isNumber() ? node.decimalValue().toPlainString() : node.asText();
             case "BYTEA":
             case "BYTES":
                 return node.asText();

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.debezium.config.Configuration;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
+import io.debezium.connector.cockroachdb.serialization.ChangefeedJsonMapper;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
@@ -77,7 +78,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
     private final CockroachDBSchema schema;
     private final Clock clock;
     private final AtomicBoolean running = new AtomicBoolean(false);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ChangefeedJsonMapper.create();
 
     /**
      * Bounded LRU cache for deduplication. Evicts oldest entries when the cache

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
@@ -125,10 +125,11 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             case "INTERVAL":
                 return SchemaBuilder.string().optional();
 
-            // JSON types
+            // JSON types. Optional like every other mapping: changefeed events can predate the
+            // registered table schema, so a required field fails conversion when the value is absent.
             case "JSON":
             case "JSONB":
-                return Json.builder();
+                return Json.builder().optional();
 
             // UUID
             case "UUID":
@@ -163,9 +164,10 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             case "BIT VARYING":
                 return SchemaBuilder.string().optional();
 
-            // pgvector-compatible VECTOR type (CockroachDB 24.2+)
+            // pgvector-compatible VECTOR type (CockroachDB 24.2+). Optional for the same reason
+            // as JSON/JSONB above.
             case "VECTOR":
-                return DoubleVector.builder();
+                return DoubleVector.builder().optional();
 
             // Geography/Geometry (CockroachDB spatial types)
             case "GEOGRAPHY":

--- a/src/main/java/io/debezium/connector/cockroachdb/serialization/ChangefeedJsonMapper.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/serialization/ChangefeedJsonMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.serialization;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Factory for the Jackson {@link ObjectMapper} used to parse changefeed JSON.
+ *
+ * <p>All changefeed payload parsing must go through this factory so numeric handling is
+ * consistent across the connector. Changefeed JSON carries DECIMAL values as JSON numbers with
+ * the full source precision; the default Jackson representation for them is a Java double,
+ * which silently rounds anything above roughly 15 to 17 significant digits. Parsing them as
+ * {@link java.math.BigDecimal} preserves the source digits exactly.</p>
+ *
+ * @author Virag Tripathi
+ */
+public final class ChangefeedJsonMapper {
+
+    private ChangefeedJsonMapper() {
+    }
+
+    public static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper()
+                .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+        // Keep the exact scale the changefeed emits (DECIMAL columns are padded to their
+        // declared scale); the default node factory strips trailing zeros.
+        mapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+        return mapper;
+    }
+}

--- a/src/main/java/io/debezium/connector/cockroachdb/serialization/ChangefeedSchemaParser.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/serialization/ChangefeedSchemaParser.java
@@ -38,7 +38,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ChangefeedSchemaParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ChangefeedSchemaParser.class);
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = ChangefeedJsonMapper.create();
 
     /**
      * Parses a CockroachDB changefeed message into a Debezium-compatible record.
@@ -233,7 +233,9 @@ public class ChangefeedSchemaParser {
             else if (node.isLong()) {
                 return node.asLong();
             }
-            else if (node.isDouble()) {
+            else if (node.isNumber()) {
+                // Remaining numbers were inferred as FLOAT64; DecimalNode also lands here
+                // because the shared mapper parses JSON floats as BigDecimal.
                 return node.asDouble();
             }
             else if (node.isBoolean()) {

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
@@ -27,7 +27,7 @@ public class CockroachDBChangeRecordEmitterTest {
 
     @Test
     public void shouldExtractTemporalColumnValuesWithCorrectJavaTypes() throws Exception {
-        // Real CockroachDB enriched changefeed output for each temporal type (captured from v25.4.11).
+        // Real CockroachDB enriched changefeed output for each temporal type (captured from v25.4.13).
         String json = "{\"d\":\"2026-06-08\",\"id\":1,\"tm\":\"11:01:45.883\",\"tmtz\":\"11:01:45.883+02\","
                 + "\"ts\":\"2026-06-08T11:01:45.883\",\"tstz\":\"2026-06-08T09:01:45.883Z\"}";
         JsonNode node = new ObjectMapper().readTree(json);

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDecimalPrecisionTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBDecimalPrecisionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.debezium.connector.cockroachdb.serialization.ChangefeedJsonMapper;
+import io.debezium.relational.Column;
+
+/**
+ * Regression test for DECIMAL precision loss.
+ *
+ * <p>Changefeed JSON carries DECIMAL values as JSON numbers with full precision. Parsing them
+ * into a Java double silently rounds anything above roughly 15 to 17 significant digits, so the
+ * emitted string no longer matches the source value. The payloads below are exactly what a
+ * CockroachDB v25.4 changefeed emits for DECIMAL(28,18), DECIMAL(16,6), and DECIMAL(14,4)
+ * columns; the connector must emit the same digits it received.</p>
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBDecimalPrecisionTest {
+
+    private static final String CHANGEFEED_AFTER = "{"
+            + "\"id\": 1, "
+            + "\"trade_dt_qty\": 9999999999.999999999000000000, "
+            + "\"cost_basis\": 9999999999.999999, "
+            + "\"seg_memo_qty\": 9999.9999"
+            + "}";
+
+    @Test
+    void decimalValuesRetainSourcePrecision() throws Exception {
+        JsonNode after = ChangefeedJsonMapper.create().readTree(CHANGEFEED_AFTER);
+        List<Column> columns = List.of(
+                column("id", "INT8", Types.BIGINT),
+                column("trade_dt_qty", "DECIMAL", Types.NUMERIC),
+                column("cost_basis", "DECIMAL", Types.NUMERIC),
+                column("seg_memo_qty", "DECIMAL", Types.NUMERIC));
+
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(after, columns);
+
+        assertThat(values[0]).isEqualTo(1L);
+        assertThat(values[1]).isEqualTo("9999999999.999999999000000000");
+        assertThat(values[2]).isEqualTo("9999999999.999999");
+        assertThat(values[3]).isEqualTo("9999.9999");
+    }
+
+    @Test
+    void decAliasRetainsSourcePrecision() throws Exception {
+        JsonNode node = ChangefeedJsonMapper.create().readTree("{\"v\": 9999999999.999999999}");
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(
+                node, List.of(column("v", "DEC", Types.NUMERIC)));
+        assertThat(values[0]).isEqualTo("9999999999.999999999");
+    }
+
+    @Test
+    void decimalValuesAvoidScientificNotation() throws Exception {
+        JsonNode node = ChangefeedJsonMapper.create().readTree(
+                "{\"tiny\": 0.000000000000000001, \"large\": 12345678901234567890.123456789}");
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(
+                node, List.of(
+                        column("tiny", "DECIMAL", Types.NUMERIC),
+                        column("large", "NUMERIC", Types.NUMERIC)));
+        assertThat(values[0]).isEqualTo("0.000000000000000001");
+        assertThat(values[1]).isEqualTo("12345678901234567890.123456789");
+    }
+
+    private static Column column(String name, String typeName, int jdbcType) {
+        return Column.editor()
+                .name(name)
+                .type(typeName)
+                .jdbcType(jdbcType)
+                .optional(true)
+                .create();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBNotNullColumnConversionTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBNotNullColumnConversionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Types;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.relational.Column;
+import io.debezium.relational.CustomConverterRegistry;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.relational.TableSchemaBuilder;
+import io.debezium.spi.topic.TopicNamingStrategy;
+
+/**
+ * Regression test for the required-field conversion failure with {@code NOT NULL} JSONB and
+ * VECTOR columns.
+ *
+ * <p>Changefeed events can predate the registered table schema, for example when the
+ * intermediate topic holds a backlog written before a column was added. Every value field must
+ * therefore be optional regardless of column nullability; a required field with no default fails
+ * {@link JsonConverter} with "Conversion error: null value for field that is required and has no
+ * default value" as soon as the value is absent.</p>
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBNotNullColumnConversionTest {
+
+    private TableSchemaBuilder tableSchemaBuilder;
+    private TopicNamingStrategy<TableId> topicNamingStrategy;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        Configuration config = Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.password", "")
+                .with("database.dbname", "defaultdb")
+                .with("topic.prefix", "test")
+                .build();
+        CockroachDBConnectorConfig connectorConfig = new CockroachDBConnectorConfig(config);
+        topicNamingStrategy = connectorConfig.getTopicNamingStrategy(CommonConnectorConfig.TOPIC_NAMING_STRATEGY);
+        tableSchemaBuilder = new TableSchemaBuilder(
+                new CockroachDBValueConverterProvider(),
+                new CockroachDBDefaultValueConverter(),
+                connectorConfig.schemaNameAdjuster(),
+                new CustomConverterRegistry(Collections.emptyList()),
+                connectorConfig.getSourceInfoStructMaker().schema(),
+                connectorConfig.getFieldNamer(),
+                false,
+                connectorConfig.getEventConvertingFailureHandlingMode());
+    }
+
+    @Test
+    void notNullJsonbAndVectorFieldsAreOptional() {
+        TableSchema tableSchema = schemaFor(tableWithNotNullJsonbAndVector());
+        assertThat(tableSchema.valueSchema().field("doc").schema().isOptional()).isTrue();
+        assertThat(tableSchema.valueSchema().field("emb").schema().isOptional()).isTrue();
+    }
+
+    @Test
+    void eventLackingNotNullJsonbAndVectorValuesConvertsWithSchemasEnabled() throws Exception {
+        TableSchema tableSchema = schemaFor(tableWithNotNullJsonbAndVector());
+
+        // An event written before doc and emb existed carries only id; the emitter supplies null
+        // for the absent columns.
+        Struct value = tableSchema.valueFromColumnData(new Object[]{ 42L, null, null });
+
+        try (JsonConverter jsonConverter = new JsonConverter()) {
+            Map<String, Object> converterConfig = new HashMap<>();
+            converterConfig.put("schemas.enable", "true");
+            converterConfig.put("converter.type", "value");
+            jsonConverter.configure(converterConfig);
+            byte[] serialized = jsonConverter.fromConnectData("test.public.diag", tableSchema.valueSchema(), value);
+            assertThat(serialized).isNotEmpty();
+        }
+    }
+
+    private Table tableWithNotNullJsonbAndVector() {
+        return Table.editor()
+                .tableId(new TableId("defaultdb", "public", "diag"))
+                .addColumn(Column.editor()
+                        .name("id")
+                        .type("INT8")
+                        .jdbcType(Types.BIGINT)
+                        .optional(false)
+                        .create())
+                .addColumn(Column.editor()
+                        .name("doc")
+                        .type("JSONB")
+                        .jdbcType(Types.OTHER)
+                        .optional(false)
+                        .create())
+                .addColumn(Column.editor()
+                        .name("emb")
+                        .type("VECTOR")
+                        .jdbcType(Types.OTHER)
+                        .optional(false)
+                        .create())
+                .setPrimaryKeyNames("id")
+                .create();
+    }
+
+    private TableSchema schemaFor(Table table) {
+        TableSchema tableSchema = tableSchemaBuilder.create(topicNamingStrategy, table, null, null, null);
+        assertThat(tableSchema.valueSchema().type()).isEqualTo(Schema.Type.STRUCT);
+        return tableSchema;
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
@@ -83,6 +83,41 @@ public class CockroachDBValueConverterProviderTest {
     }
 
     @Test
+    void jsonColumnSchemaIsOptional() {
+        assertThat(provider.schemaBuilder(column("JSON")).build().isOptional()).isTrue();
+    }
+
+    @Test
+    void jsonbColumnSchemaIsOptional() {
+        assertThat(provider.schemaBuilder(column("JSONB")).build().isOptional()).isTrue();
+    }
+
+    @Test
+    void vectorColumnSchemaIsOptional() {
+        assertThat(provider.schemaBuilder(column("VECTOR")).build().isOptional()).isTrue();
+    }
+
+    @Test
+    void everyMappedTypeReturnsAnOptionalSchema() {
+        // Changefeed events can predate the registered table schema, so every field must be
+        // optional regardless of column nullability. A required field with no default fails
+        // JsonConverter when the value is absent.
+        List<String> typeNames = List.of(
+                "BOOL", "BOOLEAN", "INT2", "SMALLINT", "INT16", "INT4", "INT", "INTEGER", "INT32",
+                "INT8", "BIGINT", "INT64", "SERIAL", "FLOAT4", "REAL", "FLOAT8", "DOUBLE PRECISION",
+                "FLOAT", "NUMERIC", "DECIMAL", "DEC", "VARCHAR", "CHAR", "CHARACTER VARYING", "TEXT",
+                "STRING", "NAME", "BYTEA", "BYTES", "BLOB", "DATE", "TIME", "TIME WITHOUT TIME ZONE",
+                "TIMETZ", "TIME WITH TIME ZONE", "TIMESTAMP", "TIMESTAMP WITHOUT TIME ZONE",
+                "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE", "INTERVAL", "JSON", "JSONB", "UUID",
+                "INET", "ENUM", "BIT", "VARBIT", "BIT VARYING", "VECTOR", "GEOGRAPHY", "GEOMETRY");
+        for (String typeName : typeNames) {
+            assertThat(provider.schemaBuilder(column(typeName)).build().isOptional())
+                    .as("schema for %s must be optional", typeName)
+                    .isTrue();
+        }
+    }
+
+    @Test
     void unknownTypeReturnsOptionalString() {
         Column col = column("SOMEFUTURETYPE");
         SchemaBuilder builder = provider.schemaBuilder(col);

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectionIT.java
@@ -35,7 +35,7 @@ import io.debezium.connector.cockroachdb.CockroachDBConnector;
 @Testcontainers
 public class CockroachDBConnectionIT {
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final Network NETWORK = Network.newNetwork();
 
     @Container

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBConnectorIT.java
@@ -40,7 +40,7 @@ public class CockroachDBConnectorIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBConnectorIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "testdb";
     private static final String TABLE_NAME = "users";
     private static final String TOPIC_PREFIX = "test-cockroachdb";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBDecimalPrecisionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBDecimalPrecisionIT.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * Integration test asserting that DECIMAL values arrive with the exact precision the source
+ * database holds.
+ *
+ * <p>Reproduces a production report: DECIMAL(28,18) and DECIMAL(16,6) values above double
+ * precision were rounded between the changefeed and the Debezium topic because changefeed JSON
+ * was parsed into Java doubles. The emitted string must match the source digits exactly.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBDecimalPrecisionIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBDecimalPrecisionIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
+    private static final String DATABASE_NAME = "decimal_testdb";
+    private static final String TABLE_NAME = "decimal_events";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
+            try (Statement stmt = defaultConn.createStatement()) {
+                stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+            }
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT8 PRIMARY KEY, "
+                    + "trade_dt_qty DECIMAL(28,18) NOT NULL DEFAULT 0.0, "
+                    + "cost_basis DECIMAL(16,6) NOT NULL DEFAULT 0.0, "
+                    + "seg_memo_qty DECIMAL(14,4) NOT NULL DEFAULT 0.0"
+                    + ")");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldEmitDecimalValuesWithSourcePrecision() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " (id, trade_dt_qty, cost_basis, seg_memo_qty) "
+                    + "VALUES (1, 9999999999.999999999, 9999999999.999999, 9999.9999)");
+        }
+
+        startTask();
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).as("Should receive the inserted row").isNotEmpty();
+
+        Struct value = (Struct) records.get(0).value();
+        Struct after = value.getStruct("after");
+        assertThat(after).isNotNull();
+
+        // The emitted strings must carry the exact source digits. Compare numerically so a
+        // representation with additional trailing zeros (the changefeed pads to the declared
+        // scale) still passes, and as strings reject any double-rounded value.
+        String tradeDtQty = after.getString("trade_dt_qty");
+        String costBasis = after.getString("cost_basis");
+        String segMemoQty = after.getString("seg_memo_qty");
+        LOGGER.info("Emitted decimals: trade_dt_qty={}, cost_basis={}, seg_memo_qty={}",
+                tradeDtQty, costBasis, segMemoQty);
+
+        assertThat(new BigDecimal(tradeDtQty)).isEqualByComparingTo(new BigDecimal("9999999999.999999999"));
+        assertThat(new BigDecimal(costBasis)).isEqualByComparingTo(new BigDecimal("9999999999.999999"));
+        assertThat(new BigDecimal(segMemoQty)).isEqualByComparingTo(new BigDecimal("9999.9999"));
+    }
+
+    private void startTask() throws Exception {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "decimal-precision-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "decimal-test");
+        config.put("topic.prefix", "decimal-test");
+        config.put("table.include.list", "public." + TABLE_NAME);
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.enriched.properties", "source,schema");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("cockroachdb.changefeed.resolved.interval", "2s");
+        config.put("snapshot.mode", "initial");
+        config.put("heartbeat.interval.ms", "1000");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+    }
+
+    private List<SourceRecord> pollForRecords(int minimum, int attempts) throws Exception {
+        List<SourceRecord> collected = new ArrayList<>();
+        for (int i = 0; i < attempts; i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null) {
+                    for (SourceRecord r : records) {
+                        if (r.topic() != null && !r.topic().contains("__debezium-heartbeat")) {
+                            collected.add(r);
+                        }
+                    }
+                }
+            }
+            catch (Exception e) {
+                LOGGER.warn("Poll failed: {}", e.getMessage());
+            }
+            if (collected.size() >= minimum) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        return collected;
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(
+                                                                                java.util.Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEndToEndIT.java
@@ -54,7 +54,7 @@ public class CockroachDBEndToEndIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBEndToEndIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "e2e_testdb";
     private static final String TABLE_NAME = "e2e_orders";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBHeartbeatIT.java
@@ -49,7 +49,7 @@ public class CockroachDBHeartbeatIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBHeartbeatIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "heartbeat_testdb";
     private static final String TABLE_NAME = "hb_events";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBMultiTableIT.java
@@ -53,7 +53,7 @@ public class CockroachDBMultiTableIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBMultiTableIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "multi_table_testdb";
     private static final String ORDERS_TABLE = "mt_orders";
     private static final String CUSTOMERS_TABLE = "mt_customers";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBNotNullJsonbSchemaChangeIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBNotNullJsonbSchemaChangeIT.java
@@ -11,24 +11,20 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.MetricValueProvider;
 import org.apache.kafka.common.metrics.PluginMetrics;
-import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,25 +40,26 @@ import org.testcontainers.utility.DockerImageName;
 import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
 
 /**
- * Integration test for signal-based incremental snapshots.
- * Verifies that:
- * <ul>
- *   <li>The connector accepts incremental snapshot configuration</li>
- *   <li>A signaling table can trigger an incremental snapshot</li>
- *   <li>Snapshot records (op=r) are emitted for the target table</li>
- * </ul>
+ * Integration test for converting events that predate a schema change adding a
+ * {@code NOT NULL JSONB} column.
+ *
+ * <p>Scenario: rows are written and their changefeed events land in the intermediate topic, the
+ * connector is restarted after {@code ALTER TABLE ... ADD COLUMN doc JSONB NOT NULL DEFAULT},
+ * and the backlog is replayed against the new table schema. The replayed events carry no value
+ * for the new column, so the emitted structs hold null for it. The JSONB field schema must be
+ * optional; a required field with no default fails {@link JsonConverter} with "Conversion error:
+ * null value for field that is required and has no default value".</p>
  *
  * @author Virag Tripathi
  */
 @Testcontainers
-public class CockroachDBIncrementalSnapshotIT {
+public class CockroachDBNotNullJsonbSchemaChangeIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBIncrementalSnapshotIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBNotNullJsonbSchemaChangeIT.class);
 
     private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
-    private static final String DATABASE_NAME = "inc_snap_testdb";
-    private static final String TABLE_NAME = "snap_products";
-    private static final String SIGNAL_TABLE = "debezium_signal";
+    private static final String DATABASE_NAME = "jsonb_backlog_testdb";
+    private static final String TABLE_NAME = "jsonb_events";
 
     private static final Network NETWORK = Network.newNetwork();
 
@@ -81,13 +78,11 @@ public class CockroachDBIncrementalSnapshotIT {
     private Connection connection;
     private CockroachDBConnectorTask task;
 
-    @AfterAll
-    static void tearDownNetwork() {
-        NETWORK.close();
-    }
-
     @BeforeEach
     public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
         String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
         try (Connection defaultConn = DriverManager.getConnection(
                 defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
@@ -101,45 +96,88 @@ public class CockroachDBIncrementalSnapshotIT {
 
         try (Statement stmt = connection.createStatement()) {
             stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
-            stmt.execute("DROP TABLE IF EXISTS " + SIGNAL_TABLE);
-            stmt.execute("DROP TABLE IF EXISTS " + TABLE_NAME);
-            stmt.execute("CREATE TABLE " + TABLE_NAME + " ("
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
                     + "id INT PRIMARY KEY, "
-                    + "name STRING NOT NULL, "
-                    + "price DECIMAL(10,2)"
+                    + "name STRING NOT NULL"
                     + ")");
-            stmt.execute("CREATE TABLE " + SIGNAL_TABLE + " ("
-                    + "id STRING PRIMARY KEY, "
-                    + "type STRING NOT NULL, "
-                    + "data STRING"
-                    + ")");
-            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Widget', 9.99)");
-            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (2, 'Gadget', 19.99)");
-            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (3, 'Gizmo', 29.99)");
         }
     }
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (task != null) {
-            try {
-                task.stop();
-            }
-            catch (Exception e) {
-                LOGGER.warn("Error stopping task: {}", e.getMessage());
-            }
-        }
+        stopTask();
         if (connection != null && !connection.isClosed()) {
             connection.close();
         }
     }
 
     @Test
-    public void shouldPerformIncrementalSnapshotViaSignalingTable() throws Exception {
-        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+    public void shouldConvertBacklogEventsAfterAddingNotNullJsonbColumn() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Alice')");
+        }
 
+        Map<String, String> config = connectorConfig();
+
+        // First task run: creates the changefeed and intermediate topic; the event for row 1 is
+        // written under the original two-column schema.
+        startTask(config);
+        List<SourceRecord> initialRecords = pollForRecords(1, 30);
+        assertThat(initialRecords).as("Should receive the pre-DDL row").isNotEmpty();
+        stopTask();
+
+        // Row 2 lands in the intermediate topic under the old schema while no task is consuming.
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (2, 'Bob')");
+        }
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("ALTER TABLE " + TABLE_NAME + " ADD COLUMN doc JSONB NOT NULL DEFAULT '{}'::JSONB");
+        }
+
+        // Second task run registers the three-column schema and replays the backlog from the
+        // earliest offset, converting the pre-DDL events against the new schema.
+        startTask(config);
+        List<SourceRecord> replayed = pollForRecords(2, 60);
+        assertThat(replayed).as("Should replay backlog events after restart").isNotEmpty();
+
+        boolean sawNullDoc = false;
+        try (JsonConverter jsonConverter = new JsonConverter()) {
+            Map<String, Object> converterConfig = new HashMap<>();
+            converterConfig.put("schemas.enable", "true");
+            converterConfig.put("converter.type", "value");
+            jsonConverter.configure(converterConfig);
+
+            for (SourceRecord record : replayed) {
+                Struct value = (Struct) record.value();
+                Struct after = value.getStruct("after");
+                if (after != null) {
+                    Field docField = after.schema().field("doc");
+                    if (docField != null) {
+                        assertThat(docField.schema().isOptional())
+                                .as("doc field schema must be optional")
+                                .isTrue();
+                        if (after.getWithoutDefault("doc") == null) {
+                            sawNullDoc = true;
+                        }
+                    }
+                }
+                // The incident failure point: serializing the full envelope with schemas enabled.
+                byte[] serialized = jsonConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+                assertThat(serialized).isNotEmpty();
+            }
+        }
+
+        LOGGER.info("Replayed {} records, sawNullDoc={}", replayed.size(), sawNullDoc);
+        assertThat(sawNullDoc)
+                .as("At least one replayed pre-DDL event should carry null for the added NOT NULL JSONB column")
+                .isTrue();
+    }
+
+    private Map<String, String> connectorConfig() {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
         Map<String, String> config = new HashMap<>();
-        config.put("name", "inc-snap-test");
+        config.put("name", "jsonb-backlog-test");
         config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
         config.put("database.hostname", cockroachdb.getHost());
         config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
@@ -147,10 +185,9 @@ public class CockroachDBIncrementalSnapshotIT {
         config.put("database.password", cockroachdb.getPassword());
         config.put("database.dbname", DATABASE_NAME);
         config.put("database.sslmode", "disable");
-        config.put("database.server.name", "inc-snap-test");
-        config.put("topic.prefix", "inc-snap");
-        config.put("table.include.list", "public." + TABLE_NAME + ",public." + SIGNAL_TABLE);
-
+        config.put("database.server.name", "jsonb-backlog");
+        config.put("topic.prefix", "jsonb-backlog");
+        config.put("table.include.list", "public." + TABLE_NAME);
         config.put("cockroachdb.changefeed.sink.type", "kafka");
         config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
         config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
@@ -158,17 +195,18 @@ public class CockroachDBIncrementalSnapshotIT {
         config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
         config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
         config.put("cockroachdb.changefeed.resolved.interval", "2s");
-        config.put("snapshot.mode", "no_data");
+        config.put("snapshot.mode", "initial");
         config.put("heartbeat.interval.ms", "1000");
-        config.put("signal.data.collection", DATABASE_NAME + ".public." + SIGNAL_TABLE);
         config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+        return config;
+    }
 
+    private void startTask(Map<String, String> config) throws Exception {
         task = new CockroachDBConnectorTask();
         task.initialize(createMockContext());
 
         AtomicReference<Throwable> taskError = new AtomicReference<>();
         CountDownLatch started = new CountDownLatch(1);
-
         Thread taskThread = new Thread(() -> {
             try {
                 task.start(config);
@@ -185,26 +223,29 @@ public class CockroachDBIncrementalSnapshotIT {
         boolean didStart = started.await(30, TimeUnit.SECONDS);
         assertThat(didStart).as("Task should start within 30 seconds").isTrue();
         assertThat(taskError.get()).as("Task should start without error").isNull();
+    }
 
-        // Let streaming settle -- with no_data snapshot, changefeed starts with cursor=now
-        Thread.sleep(5000);
-
-        // Insert a streaming record first (op=c) so we know streaming is working
-        try (Statement stmt = connection.createStatement()) {
-            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (4, 'NewItem', 39.99)");
+    private void stopTask() {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+            task = null;
         }
+    }
 
-        // Poll for the streaming record
-        List<SourceRecord> streamingRecords = new ArrayList<>();
-        for (int i = 0; i < 20; i++) {
+    private List<SourceRecord> pollForRecords(int minimum, int attempts) throws Exception {
+        List<SourceRecord> collected = new ArrayList<>();
+        for (int i = 0; i < attempts; i++) {
             try {
                 List<SourceRecord> records = task.poll();
                 if (records != null) {
                     for (SourceRecord r : records) {
                         if (r.topic() != null && !r.topic().contains("__debezium-heartbeat")) {
-                            streamingRecords.add(r);
-                            LOGGER.info("Streaming record: topic={}, op={}", r.topic(),
-                                    ((Struct) r.value()).getString("op"));
+                            collected.add(r);
                         }
                     }
                 }
@@ -212,60 +253,12 @@ public class CockroachDBIncrementalSnapshotIT {
             catch (Exception e) {
                 LOGGER.warn("Poll failed: {}", e.getMessage());
             }
-            if (!streamingRecords.isEmpty()) {
+            if (collected.size() >= minimum) {
                 break;
             }
             Thread.sleep(1000);
         }
-        assertThat(streamingRecords).as("Should receive streaming record").isNotEmpty();
-        LOGGER.info("Streaming is active, received {} records", streamingRecords.size());
-
-        // Now trigger incremental snapshot via the signaling table
-        LOGGER.info("Triggering incremental snapshot via signaling table...");
-        try (Statement stmt = connection.createStatement()) {
-            stmt.execute("INSERT INTO " + SIGNAL_TABLE + " VALUES ("
-                    + "'inc-snap-1', "
-                    + "'execute-snapshot', "
-                    + "'{\"data-collections\": [\"" + DATABASE_NAME + ".public." + TABLE_NAME + "\"]}'::STRING"
-                    + ")");
-        }
-        LOGGER.info("Signal inserted, waiting for incremental snapshot records...");
-
-        // Poll for snapshot records (op=r) from the incremental snapshot
-        List<SourceRecord> snapshotRecords = new ArrayList<>();
-        for (int i = 0; i < 45; i++) {
-            try {
-                List<SourceRecord> records = task.poll();
-                if (records != null) {
-                    for (SourceRecord r : records) {
-                        if (r.topic() != null && !r.topic().contains("__debezium-heartbeat")) {
-                            Struct value = (Struct) r.value();
-                            String op = value.getString("op");
-                            if ("r".equals(op)) {
-                                snapshotRecords.add(r);
-                                Struct after = value.getStruct("after");
-                                LOGGER.info("Snapshot record: op={}, id={}, name={}",
-                                        op, after.get("id"), after.get("name"));
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception e) {
-                LOGGER.warn("Poll failed: {}", e.getMessage());
-            }
-            if (snapshotRecords.size() >= 4) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-
-        LOGGER.info("Incremental snapshot IT results: {} streaming records, {} snapshot records",
-                streamingRecords.size(), snapshotRecords.size());
-
-        // We should have the 3 original rows + 1 new row = 4 snapshot records
-        assertThat(snapshotRecords).as("Should receive incremental snapshot records (op=r)")
-                .hasSizeGreaterThanOrEqualTo(4);
+        return collected;
     }
 
     private SourceTaskContext createMockContext() {
@@ -280,7 +273,7 @@ public class CockroachDBIncrementalSnapshotIT {
                 return new OffsetStorageReader() {
                     @Override
                     public <T> Map<String, Object> offset(Map<String, T> partition) {
-                        return Collections.emptyMap();
+                        return null;
                     }
 
                     @Override
@@ -293,29 +286,7 @@ public class CockroachDBIncrementalSnapshotIT {
 
             @Override
             public PluginMetrics pluginMetrics() {
-                return new PluginMetrics() {
-                    @Override
-                    public MetricName metricName(String name, String description, LinkedHashMap<String, String> tags) {
-                        return new MetricName(name, "test", description, tags);
-                    }
-
-                    @Override
-                    public void addMetric(MetricName name, MetricValueProvider<?> provider) {
-                    }
-
-                    @Override
-                    public void removeMetric(MetricName name) {
-                    }
-
-                    @Override
-                    public Sensor addSensor(String name) {
-                        return null;
-                    }
-
-                    @Override
-                    public void removeSensor(String name) {
-                    }
-                };
+                return null;
             }
         };
     }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRestartResumeIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRestartResumeIT.java
@@ -56,7 +56,7 @@ public class CockroachDBRestartResumeIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBRestartResumeIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "restartresume_testdb";
     private static final String TABLE_NAME = "restartresume_orders";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSchemaEvolutionIT.java
@@ -50,7 +50,7 @@ public class CockroachDBSchemaEvolutionIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSchemaEvolutionIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "schema_evo_testdb";
     private static final String TABLE_NAME = "evo_events";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotIT.java
@@ -47,7 +47,7 @@ public class CockroachDBSnapshotIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSnapshotIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "snapshot_testdb";
     private static final String TABLE_NAME = "products";
     private static final String TOPIC_PREFIX = "snapshot-test";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotLifecycleIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSnapshotLifecycleIT.java
@@ -51,7 +51,7 @@ public class CockroachDBSnapshotLifecycleIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSnapshotLifecycleIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "snaplifecycle_testdb";
     private static final String TABLE_NAME = "snaplifecycle_orders";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBStreamingIT.java
@@ -47,7 +47,7 @@ public class CockroachDBStreamingIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBStreamingIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "streaming_testdb";
     private static final String TABLE_NAME = "orders";
     private static final String TOPIC_PREFIX = "streaming-test";

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBTemporalTypesIT.java
@@ -53,7 +53,7 @@ public class CockroachDBTemporalTypesIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBTemporalTypesIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.11");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "temporal_testdb";
     private static final String TABLE_NAME = "temporal_types";
 


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2256

Stacked on #55; the first commit belongs to that PR and drops out once it merges.

Problem

Changefeed JSON was parsed with a default Jackson ObjectMapper, which represents JSON decimal numbers as Java double. DECIMAL column values above roughly 15 to 17 significant digits were rounded before the value converters ran: DECIMAL(28,18) 9999999999.999999999 became 1.0E10 and DECIMAL(16,6) 9999999999.999999 became 9999999999.999998, while DECIMAL(14,4) values survived. The changefeed payload carries full precision, verified on CockroachDB v25.4.13 with a sinkless CREATE CHANGEFEED, so the loss occurred entirely in the connector. Reported from a production pipeline.

Change

Introduce ChangefeedJsonMapper, used by the streaming source and the schema parser, that enables USE_BIG_DECIMAL_FOR_FLOATS and exact BigDecimal node handling. Emit DECIMAL and NUMERIC values with BigDecimal.toPlainString, add the missing DEC alias, and align the legacy schema parser's FLOAT64 conversion with BigDecimal-based nodes.

Verification

The new unit tests and CockroachDBDecimalPrecisionIT fail on the previous code, reproducing the reported values through a real CockroachDB pipeline, and pass with the change. Full unit suite 224 tests green and integration suite 42 tests green on v25.4.13, cloud connection suite green, and the crdb-to-crdb, crdb-to-crdb-mtls, and crdb-to-sinkless example pipelines run end to end with the fixed build, including a new demo check asserting all 19 significant digits of a DECIMAL(28,18) value arrive in the change events.