### PR TITLE
debezium/dbz#2024 Add sinkless changefeed delivery mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Example connector configuration:
 | Option                                       | Default  | Description                                   |
 |----------------------------------------------|----------|-----------------------------------------------|
 | `cockroachdb.changefeed.enriched.properties` | source   | Comma-separated enriched properties (passthrough to CockroachDB) |
-| `cockroachdb.changefeed.sink.type`           | kafka    | Sink type (kafka, webhook, pubsub, etc.)      |
-| `cockroachdb.changefeed.sink.uri`            | -        | Sink URI (required). e.g. `kafka://host:port`. Do not set `topic_name`/`topic_prefix` here |
+| `cockroachdb.changefeed.sink.type`           | kafka    | Changefeed delivery mode: `kafka` (changefeed pushes to an intermediate Kafka that the connector consumes) or `sinkless` (changefeed streams over the connector's SQL connection, no intermediate Kafka). See [Changefeed delivery modes](#changefeed-delivery-modes-kafka-vs-sinkless). Planned: webhook, pubsub, cloudstorage |
+| `cockroachdb.changefeed.sink.uri`            | -        | Sink URI. **Required for `sink.type=kafka`**, e.g. `kafka://host:port`; ignored for `sink.type=sinkless`. Do not set `topic_name`/`topic_prefix` here |
 | `cockroachdb.changefeed.sink.topic.prefix`   | ""       | Prefix for intermediate topic names, used verbatim: topics are `<prefix><database>.<schema>.<table>`. Include your own separator (e.g. `crdb.`). If empty, defaults to `<topic.prefix>.` |
 | `cockroachdb.changefeed.max.tables.per.changefeed` | 0  | Max tables per changefeed. `0` = all in one. Set positive to split large table sets across multiple changefeeds and avoid per-table coupling |
 | `cockroachdb.changefeed.sink.options`        | ""       | Additional sink options in key=value format   |
@@ -128,6 +128,36 @@ Example connector configuration:
 | `cockroachdb.changefeed.cursor`              | now      | Start cursor position                         |
 | `cockroachdb.changefeed.batch.size`          | 1000     | Batch size for changefeed processing          |
 | `cockroachdb.changefeed.poll.interval.ms`    | 100      | Poll interval in milliseconds                 |
+
+#### Changefeed delivery modes (kafka vs sinkless)
+
+CockroachDB can run a changefeed two ways, selected by `cockroachdb.changefeed.sink.type`:
+
+- **`kafka`** (default): the connector creates a changefeed with `INTO 'kafka://...'`, so CockroachDB
+  pushes change events to an intermediate Kafka cluster, and the connector runs its own consumer to
+  read them back. This consumer is a separate client to secure (see the changefeed TLS options) and
+  operate, but the intermediate topics durably buffer change events independently of the connector.
+  `cockroachdb.changefeed.sink.uri` is required.
+
+- **`sinkless`**: the connector creates a [core (sinkless) changefeed](https://www.cockroachlabs.com/docs/stable/changefeed-for)
+  with `CREATE CHANGEFEED FOR TABLE ...` and **no** `INTO` clause, and streams the change events back
+  over its own SQL connection. There is no intermediate Kafka, no changefeed job
+  (`SHOW CHANGEFEED JOBS` does not list it), and no separate consumer to secure: security collapses
+  onto the single JDBC connection the connector already uses. `cockroachdb.changefeed.sink.uri` is
+  not used. The Debezium output is identical to `kafka` mode.
+
+The output topics the connector produces (and the Debezium envelope) are the same in both modes; only
+the ingestion path differs. A runnable example is in
+[`crdb-to-sinkless`](https://github.com/viragtripathi/debezium-cockroachdb-examples/tree/main/crdb-to-sinkless).
+
+**Durability tradeoff:** `kafka` mode buffers change events in Kafka, so the connector can be down for
+a long time and still resume from the intermediate topics. `sinkless` mode has no intermediate buffer:
+if the connector stops, the changefeed stops, and resume is bounded by CockroachDB's garbage-collection
+window ([`gc.ttlseconds`](https://www.cockroachlabs.com/docs/stable/configure-replication-zones#gc-ttlseconds),
+whose default varies by version and deployment). The connector resumes from the persisted resolved
+timestamp (`cursor`), but CockroachDB can only serve changes newer than the GC window; if the connector
+is down longer than the GC TTL, a new snapshot is required. Size `gc.ttlseconds` for your worst-case
+connector downtime if you rely on sinkless resume.
 
 #### Snapshot Configuration
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -273,7 +273,13 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withWidth(Width.SHORT)
             .withImportance(Importance.HIGH)
             .withValidation(CockroachDBConnectorConfig::validateChangefeedSinkType)
-            .withDescription("The type of sink for changefeed events. Currently supported: 'kafka'. Planned: 'webhook', 'pubsub', 'cloudstorage'.");
+            .withDescription("How the connector receives changefeed events. "
+                    + "'kafka' (default): CockroachDB pushes the changefeed to an intermediate Kafka cluster "
+                    + "(set via cockroachdb.changefeed.sink.uri) and the connector consumes it. "
+                    + "'sinkless': the connector runs a CockroachDB sinkless changefeed (CREATE CHANGEFEED without INTO) "
+                    + "and streams change events directly over its SQL connection, with no intermediate Kafka cluster; "
+                    + "cockroachdb.changefeed.sink.uri is not used in this mode. "
+                    + "Planned: 'webhook', 'pubsub', 'cloudstorage'.");
 
     public static final Field CHANGEFEED_SINK_URI = Field.create("cockroachdb.changefeed.sink.uri")
             .withDisplayName("Changefeed sink URI")
@@ -909,8 +915,8 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     private static int validateChangefeedSinkType(Configuration config, Field field, Field.ValidationOutput problems) {
         String value = config.getString(field);
-        if (value != null && !value.equals("kafka")) {
-            problems.accept(field, value, "Currently only 'kafka' is supported. Planned: webhook, pubsub, cloudstorage");
+        if (value != null && !value.equals("kafka") && !value.equals("sinkless")) {
+            problems.accept(field, value, "Must be 'kafka' or 'sinkless'. Planned: webhook, pubsub, cloudstorage");
             return 1;
         }
         return 0;
@@ -1064,6 +1070,15 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
     // Sink-related getter methods
     public String getChangefeedSinkType() {
         return config.getString(CHANGEFEED_SINK_TYPE);
+    }
+
+    /**
+     * Returns {@code true} when the connector should use a CockroachDB sinkless changefeed
+     * (CREATE CHANGEFEED without INTO) and stream change events directly over the SQL connection,
+     * rather than pushing to an intermediate Kafka cluster and consuming it back.
+     */
+    public boolean isSinklessChangefeed() {
+        return "sinkless".equals(getChangefeedSinkType());
     }
 
     public String getChangefeedSinkUri() {

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -10,27 +10,37 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -193,7 +203,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 LOGGER.debug("Mapped topic {} -> table {}", topicName, table);
             }
 
-            // Create a single multi-table changefeed (if not already running)
+            // Create a single multi-table changefeed (if not already running). For sinkless mode
+            // this is a no-op; the changefeed is created and streamed during consumption.
             createChangefeeds(connection, tables, offsetContext, hasPriorOffset);
 
             // Drive the snapshot lifecycle for the changefeed initial scan so snapshot_completed,
@@ -214,8 +225,9 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 offsetContext.preSnapshotCompletion();
             }
 
-            // Consume events from all per-table topics in a single consumer
-            consumeChangefeedEvents(tables, offsetContext, context);
+            // Consume events: from the intermediate Kafka topics (kafka mode) or directly from a
+            // sinkless changefeed streamed over SQL (sinkless mode).
+            consumeChangefeedEvents(tables, offsetContext, context, hasPriorOffset);
         }
         catch (SQLException e) {
             // CockroachDB is the authority on changefeed options (sink URI, enriched_properties,
@@ -255,6 +267,13 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                                    CockroachDBOffsetContext offsetContext,
                                    boolean hasPriorOffset)
             throws SQLException {
+
+        if (config.isSinklessChangefeed()) {
+            // A sinkless changefeed is created and streamed in a single executeQuery during
+            // consumption (see consumeSinkless), so there is nothing to pre-create here.
+            initialScanInProgress = "yes".equals(config.getInitialScanForSnapshotMode(hasPriorOffset));
+            return;
+        }
 
         int maxPerChangefeed = config.getChangefeedMaxTablesPerChangefeed();
         List<List<TableId>> groups = partitionTables(tables, maxPerChangefeed);
@@ -309,11 +328,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      */
     static List<List<TableId>> partitionTables(List<TableId> tables, int maxPerGroup) {
         if (maxPerGroup <= 0 || tables.size() <= maxPerGroup) {
-            return List.of(new java.util.ArrayList<>(tables));
+            return List.of(new ArrayList<>(tables));
         }
-        List<List<TableId>> groups = new java.util.ArrayList<>();
+        List<List<TableId>> groups = new ArrayList<>();
         for (int i = 0; i < tables.size(); i += maxPerGroup) {
-            groups.add(new java.util.ArrayList<>(tables.subList(i, Math.min(i + maxPerGroup, tables.size()))));
+            groups.add(new ArrayList<>(tables.subList(i, Math.min(i + maxPerGroup, tables.size()))));
         }
         return groups;
     }
@@ -323,7 +342,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * Subscribes to all per-table topics in a single consumer for concurrent processing.
      */
     private void consumeChangefeedEvents(List<TableId> tables, CockroachDBOffsetContext offsetContext,
-                                         ChangeEventSourceContext context)
+                                         ChangeEventSourceContext context, boolean hasPriorOffset)
             throws InterruptedException {
         String sinkType = config.getChangefeedSinkType();
         LOGGER.debug("Routing to sink consumer type='{}' for {} table(s)", sinkType, tables.size());
@@ -331,10 +350,13 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             case "kafka":
                 consumeFromKafkaTopics(tables, offsetContext, context);
                 break;
+            case "sinkless":
+                consumeSinkless(tables, offsetContext, context, hasPriorOffset);
+                break;
             default:
                 throw new IllegalArgumentException(
                         "Unsupported changefeed sink type: '" + sinkType
-                                + "'. Currently supported: kafka. Planned: webhook, pubsub, cloudstorage.");
+                                + "'. Supported: kafka, sinkless. Planned: webhook, pubsub, cloudstorage.");
         }
     }
 
@@ -403,7 +425,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 .map(this::buildTopicName)
                 .collect(Collectors.toList());
 
-        java.util.Properties props = new java.util.Properties();
+        Properties props = new Properties();
         String explicitBootstrap = config.getChangefeedKafkaBootstrapServers();
         if (explicitBootstrap != null && !explicitBootstrap.trim().isEmpty()) {
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, explicitBootstrap);
@@ -518,6 +540,135 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      */
     static String kafkaConsumerOffsetKey(String topic, int partition) {
         return topic + ":" + partition;
+    }
+
+    /**
+     * Consumes a CockroachDB sinkless changefeed: runs {@code CREATE CHANGEFEED ... } without
+     * {@code INTO} on a dedicated SQL connection and streams change events directly from the
+     * resulting {@link ResultSet}, with no intermediate Kafka cluster. Each row's {@code value}
+     * column is the same enriched JSON the kafka path receives, so it is handed to the shared
+     * {@link #processChangefeedEvent} pipeline (parse, dedup, schema refresh, dispatch, and
+     * resolved-timestamp offset advancement) unchanged.
+     */
+    private void consumeSinkless(List<TableId> tables, CockroachDBOffsetContext offsetContext,
+                                 ChangeEventSourceContext context, boolean hasPriorOffset)
+            throws InterruptedException {
+        Map<String, TableId> tablesBySchemaAndName = new HashMap<>();
+        for (TableId table : tables) {
+            tablesBySchemaAndName.put(table.schema() + "." + table.table(), table);
+        }
+
+        String changefeedQuery = buildSinklessChangefeedQuery(tables, offsetContext.getCursor(), hasPriorOffset);
+        LOGGER.info("Starting sinkless changefeed for {} table(s) (streaming over SQL, no intermediate Kafka)", tables.size());
+        LOGGER.debug("Sinkless changefeed query: {}", changefeedQuery);
+
+        // The streaming query holds its connection open indefinitely, so it must use a dedicated
+        // connection separate from the schema-refresh connection opened in execute().
+        try (CockroachDBConnection streamConnection = new CockroachDBConnection(config)) {
+            streamConnection.connect();
+            Connection jdbc = streamConnection.connection();
+            // A sinkless changefeed must stream over a server-side cursor: pgjdbc only enables that
+            // when autoCommit is false and a fetch size is set. CockroachDB treats CREATE CHANGEFEED
+            // as DDL and, by default (the autocommit_before_ddl session setting), auto-commits the
+            // surrounding transaction before running it, which tears the cursor down mid-execute and
+            // closes the connection (EOFException). Disabling autocommit_before_ddl on this session
+            // lets the changefeed run inside pgjdbc's transaction so the cursor streams. See
+            // CockroachDB issue #85436.
+            try (Statement init = jdbc.createStatement()) {
+                init.execute("SET autocommit_before_ddl = false");
+            }
+            jdbc.setAutoCommit(false);
+            try (Statement stmt = jdbc.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
+                // Fetch one row at a time. The change stream is unbounded and CockroachDB does not
+                // return a partial cursor batch, so any fetch size greater than one would withhold
+                // events until that many rows accumulated, which is unacceptable latency for CDC.
+                // Row-at-a-time delivers each change (and each resolved timestamp) as soon as
+                // CockroachDB emits it. This is independent of cockroachdb.changefeed.batch.size,
+                // which governs the kafka-mode consumer poll, not the SQL cursor.
+                stmt.setFetchSize(1);
+                try (ResultSet rs = stmt.executeQuery(changefeedQuery)) {
+                    while (context.isRunning() && running.get() && rs.next()) {
+                        String valueJson = readChangefeedValue(rs);
+                        if (valueJson == null || valueJson.trim().isEmpty()) {
+                            continue;
+                        }
+                        String keyJson = readChangefeedKey(rs);
+                        TableId table = resolveTableFromSource(valueJson, tablesBySchemaAndName);
+                        // Resolved-timestamp rows carry no table; processChangefeedEvent handles
+                        // them by their "resolved" field regardless of the table argument.
+                        processChangefeedEvent(keyJson, valueJson, table, offsetContext);
+
+                        if (config.getSnapshotMode() == CockroachDBConnectorConfig.SnapshotMode.INITIAL_ONLY
+                                && !initialScanInProgress) {
+                            LOGGER.info("Initial scan completed and snapshot.mode=initial_only, stopping connector");
+                            running.set(false);
+                            break;
+                        }
+                    }
+                }
+            }
+            LOGGER.debug("Stopped sinkless changefeed consumption");
+        }
+        catch (SQLException e) {
+            // On shutdown the dedicated streaming connection is closed out from under the open
+            // cursor, which surfaces here as an I/O error ("sending to the backend" / EOF). That is
+            // the expected way a never-ending changefeed read ends, not a failure, so do not escalate
+            // it when the source is already stopping.
+            if (!context.isRunning() || !running.get()) {
+                LOGGER.info("Sinkless changefeed consumption stopped during shutdown");
+                return;
+            }
+            LOGGER.error("Error in sinkless changefeed consumption: {}", e.getMessage(), e);
+            throw new RuntimeException("Failed to stream sinkless changefeed from CockroachDB: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Reads the changefeed {@code value} column. CockroachDB returns it as BYTES, so prefer
+     * {@code getBytes} and decode UTF-8, falling back to {@code getString}.
+     */
+    private static String readChangefeedKey(ResultSet rs) throws SQLException {
+        try {
+            byte[] bytes = rs.getBytes("key");
+            if (bytes != null) {
+                return new String(bytes, StandardCharsets.UTF_8);
+            }
+            return rs.getString("key");
+        }
+        catch (SQLException e) {
+            // Resolved-timestamp rows and older server versions may not expose a key column.
+            return null;
+        }
+    }
+
+    private static String readChangefeedValue(ResultSet rs) throws SQLException {
+        byte[] bytes = rs.getBytes("value");
+        if (bytes != null) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return rs.getString("value");
+    }
+
+    /**
+     * Resolves the {@link TableId} for a sinkless changefeed row from the event's enriched
+     * {@code source} block ({@code schema_name} + {@code table_name}), which is schema-qualified so
+     * same-named tables in different schemas route correctly. Returns null for rows without a usable
+     * source (for example resolved-timestamp rows), which the caller passes through harmlessly.
+     */
+    TableId resolveTableFromSource(String valueJson, Map<String, TableId> tablesBySchemaAndName) {
+        try {
+            JsonNode payload = resolvePayload(objectMapper.readTree(valueJson));
+            JsonNode source = payload.path("source");
+            String schema = source.path("schema_name").asText(null);
+            String table = source.path("table_name").asText(null);
+            if (schema != null && table != null) {
+                return tablesBySchemaAndName.get(schema + "." + table);
+            }
+        }
+        catch (Exception e) {
+            LOGGER.debug("Could not resolve table from sinkless event source block: {}", e.getMessage());
+        }
+        return null;
     }
 
     /**
@@ -737,44 +888,66 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         sinkUri = sinkUri + separator + "topic_prefix=" + sanitizeLiteral(resolveTopicPrefix());
         query.append(" INTO '").append(sanitizeLiteral(sinkUri)).append("'");
 
-        query.append(" WITH full_table_name");
-        // The connector parses only the enriched envelope (it relies on the 'op' and 'ts_ns'
-        // fields it provides), so the envelope is fixed rather than configurable.
-        query.append(", envelope = 'enriched'");
+        // full_table_name is kafka-specific: it drives the per-table topic naming the consumer
+        // subscribes to. The remaining options are shared with the sinkless changefeed.
+        query.append(" WITH full_table_name, ").append(buildChangefeedWithOptions(cursor, hasPriorOffset));
+        return query.toString();
+    }
+
+    /**
+     * Builds the {@code CREATE CHANGEFEED} statement for a sinkless changefeed: no {@code INTO},
+     * no {@code topic_prefix}, no {@code full_table_name}, and no sink TLS injection. CockroachDB
+     * streams the change events back over the SQL connection (see {@link #consumeSinkless}).
+     */
+    String buildSinklessChangefeedQuery(List<TableId> tables, String cursor, boolean hasPriorOffset) {
+        StringBuilder query = new StringBuilder();
+        query.append("CREATE CHANGEFEED FOR TABLE ");
+        query.append(tables.stream()
+                .map(t -> sanitizeIdentifier(t.toString()))
+                .collect(Collectors.joining(", ")));
+        query.append(" WITH ").append(buildChangefeedWithOptions(cursor, hasPriorOffset));
+        return query.toString();
+    }
+
+    /**
+     * Builds the comma-separated {@code WITH} options shared by the sink-based and sinkless
+     * changefeeds: the fixed enriched envelope, enriched_properties, updated/diff, the resolved
+     * interval, the snapshot-derived initial_scan, an optional resume cursor, and any user sink
+     * options. Returned without a leading comma so callers can prefix it with their own options
+     * (for example {@code full_table_name} for the kafka sink).
+     */
+    private String buildChangefeedWithOptions(String cursor, boolean hasPriorOffset) {
+        List<String> options = new ArrayList<>();
+        // The connector parses only the enriched envelope (it relies on the 'op' and 'ts_ns' fields
+        // it provides), so the envelope is fixed rather than configurable.
+        options.add("envelope = 'enriched'");
 
         String enrichedProperties = config.getChangefeedEnrichedProperties();
         if (enrichedProperties != null && !enrichedProperties.trim().isEmpty()) {
-            query.append(", enriched_properties = '").append(sanitizeLiteral(enrichedProperties)).append("'");
+            options.add("enriched_properties = '" + sanitizeLiteral(enrichedProperties) + "'");
         }
-
         if (config.isChangefeedIncludeUpdated()) {
-            query.append(", updated");
+            options.add("updated");
         }
-
         if (config.isChangefeedIncludeDiff()) {
-            query.append(", diff");
+            options.add("diff");
         }
-
-        String resolvedInterval = config.getChangefeedResolvedInterval();
-        query.append(", resolved = '").append(sanitizeLiteral(resolvedInterval)).append("'");
+        options.add("resolved = '" + sanitizeLiteral(config.getChangefeedResolvedInterval()) + "'");
 
         String initialScan = config.getInitialScanForSnapshotMode(hasPriorOffset);
         if (initialScan != null) {
-            query.append(", initial_scan = '").append(sanitizeLiteral(initialScan)).append("'");
+            options.add("initial_scan = '" + sanitizeLiteral(initialScan) + "'");
         }
-
         if (cursor != null && !cursor.trim().isEmpty()
                 && !CockroachDBOffsetContext.CURSOR_INITIAL.equals(cursor)
                 && !CockroachDBOffsetContext.CURSOR_NOW.equals(cursor)) {
-            query.append(", cursor = '").append(sanitizeLiteral(cursor)).append("'");
+            options.add("cursor = '" + sanitizeLiteral(cursor) + "'");
         }
-
         String sinkOptions = config.getChangefeedSinkOptions();
         if (sinkOptions != null && !sinkOptions.trim().isEmpty()) {
-            query.append(", ").append(sanitizeLiteral(sinkOptions));
+            options.add(sanitizeLiteral(sinkOptions));
         }
-
-        return query.toString();
+        return String.join(", ", options);
     }
 
     /**
@@ -872,6 +1045,13 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
     static final String CONSUMER_OVERRIDE_PREFIX = "cockroachdb.changefeed.kafka.consumer.override.";
 
     /**
+     * Kafka SSL store type for inline PEM material. Kafka exposes constants for the SSL config keys
+     * (see {@link SslConfigs}) but not for this store-type value, so it is named here. It lets the
+     * consumer reuse the connector's PEM sink TLS files directly without converting them to a JKS store.
+     */
+    private static final String PEM_STORE_TYPE = "PEM";
+
+    /**
      * Configures security for the connector's changefeed consumer. The consumer is a normal Kafka
      * client and is separate from the changefeed push to CockroachDB's Kafka sink, so it needs its
      * own security settings to read from a secured broker.
@@ -886,20 +1066,20 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * overrides the derived values and covers SASL, JKS stores, or a differently-secured broker.</li>
      * </ol>
      */
-    static void applyConsumerSecurity(CockroachDBConnectorConfig config, java.util.Properties props) {
+    static void applyConsumerSecurity(CockroachDBConnectorConfig config, Properties props) {
         if (config.isChangefeedSinkTlsEnabled()) {
-            props.put("security.protocol", "SSL");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name());
             String caCert = config.getChangefeedSinkTlsCaCertFile();
             if (caCert != null && !caCert.isEmpty()) {
-                props.put("ssl.truststore.type", "PEM");
-                props.put("ssl.truststore.location", caCert);
+                props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_STORE_TYPE);
+                props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, caCert);
             }
             String clientCert = config.getChangefeedSinkTlsClientCertFile();
             String clientKey = config.getChangefeedSinkTlsClientKeyFile();
             if (clientCert != null && !clientCert.isEmpty() && clientKey != null && !clientKey.isEmpty()) {
-                props.put("ssl.keystore.type", "PEM");
-                props.put("ssl.keystore.certificate.chain", readFileContent(clientCert));
-                props.put("ssl.keystore.key", readFileContent(clientKey));
+                props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, PEM_STORE_TYPE);
+                props.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, readFileContent(clientCert));
+                props.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, readFileContent(clientKey));
             }
             LOGGER.info("Derived SSL config for the changefeed consumer from cockroachdb.changefeed.sink.tls.* (security.protocol=SSL)");
         }
@@ -939,8 +1119,8 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         }
         String base = uri.substring(0, queryStart);
         String query = uri.substring(queryStart + 1);
-        java.util.Set<String> toRemove = java.util.Set.of(keys);
-        String kept = java.util.Arrays.stream(query.split("&"))
+        Set<String> toRemove = Set.of(keys);
+        String kept = Arrays.stream(query.split("&"))
                 .filter(pair -> !pair.isEmpty())
                 .filter(pair -> {
                     int eq = pair.indexOf('=');
@@ -983,7 +1163,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      */
     static boolean hasSchemaChanged(JsonNode dataNode, io.debezium.relational.Table table) {
         // Check for new columns: event field not in registered schema
-        java.util.Iterator<String> fieldNames = dataNode.fieldNames();
+        Iterator<String> fieldNames = dataNode.fieldNames();
         int eventFieldCount = 0;
         while (fieldNames.hasNext()) {
             String field = fieldNames.next();

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -490,6 +490,31 @@ public class CockroachDBConnectorConfigTest {
                 CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
     }
 
+    @Test
+    public void shouldAcceptSinklessSinkType() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.type", "sinkless")
+                .build();
+        assertThat(config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                CockroachDBConnectorConfigTest::failOnProblem)).isTrue();
+        assertThat(new CockroachDBConnectorConfig(config).isSinklessChangefeed()).isTrue();
+    }
+
+    @Test
+    public void shouldRejectUnknownSinkType() {
+        Configuration config = baseProps()
+                .with("cockroachdb.changefeed.sink.type", "rabbitmq")
+                .build();
+        StringBuilder problemMessage = new StringBuilder();
+        boolean ok = config.validateAndRecord(
+                CockroachDBConnectorConfig.ALL_FIELDS,
+                (String message) -> problemMessage.append(message));
+        assertThat(ok).isFalse();
+        assertThat(problemMessage.toString()).contains("kafka");
+        assertThat(problemMessage.toString()).contains("sinkless");
+    }
+
     private static Configuration.Builder baseProps() {
         return Configuration.create()
                 .with("database.hostname", "localhost")

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+
+/**
+ * Unit tests for the sinkless changefeed delivery mode (cockroachdb.changefeed.sink.type=sinkless):
+ * the no-INTO changefeed query and the source-block table routing.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBSinklessTest {
+
+    private CockroachDBStreamingChangeEventSource createSource(Configuration config) {
+        return new CockroachDBStreamingChangeEventSource(new CockroachDBConnectorConfig(config), null, null, null, null);
+    }
+
+    private Configuration.Builder sinklessConfig() {
+        return Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("database.server.name", "test")
+                .with("topic.prefix", "crdb")
+                .with("cockroachdb.changefeed.sink.type", "sinkless")
+                .with("cockroachdb.changefeed.include.diff", "true")
+                .with("cockroachdb.changefeed.resolved.interval", "10s");
+    }
+
+    @Test
+    public void shouldBuildSinklessQueryWithoutSinkClauses() {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        String query = source.buildSinklessChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders")), null, false);
+
+        assertThat(query).startsWith("CREATE CHANGEFEED FOR TABLE");
+        assertThat(query).contains("envelope = 'enriched'");
+        assertThat(query).contains("resolved = '10s'");
+        assertThat(query).contains("diff");
+        // No sink-specific clauses for a sinkless changefeed.
+        assertThat(query).doesNotContain("INTO");
+        assertThat(query).doesNotContain("topic_prefix");
+        assertThat(query).doesNotContain("full_table_name");
+    }
+
+    @Test
+    public void shouldIncludeCursorWhenResuming() {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        String query = source.buildSinklessChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders")), "1700000000000000000.0000000000", true);
+        assertThat(query).contains("cursor = '1700000000000000000.0000000000'");
+    }
+
+    @Test
+    public void shouldSupportMultipleTablesInOneSinklessChangefeed() {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        String query = source.buildSinklessChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders"),
+                        new TableId("testdb", "inventory", "warehouse_items")),
+                null, false);
+        assertThat(query).contains("public.orders");
+        assertThat(query).contains("inventory.warehouse_items");
+    }
+
+    @Test
+    public void shouldResolveTableFromSourceBlockBySchemaAndName() throws Exception {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        Map<String, TableId> map = new HashMap<>();
+        TableId publicOrders = new TableId("testdb", "public", "orders");
+        TableId inventoryOrders = new TableId("testdb", "inventory", "orders");
+        map.put("public.orders", publicOrders);
+        map.put("inventory.orders", inventoryOrders);
+
+        String publicEvent = "{\"after\":{\"id\":1},\"op\":\"c\",\"source\":{\"schema_name\":\"public\",\"table_name\":\"orders\"}}";
+        String inventoryEvent = "{\"after\":{\"id\":1},\"op\":\"c\",\"source\":{\"schema_name\":\"inventory\",\"table_name\":\"orders\"}}";
+
+        // Same table name, different schema: must route to the correct TableId.
+        assertThat(source.resolveTableFromSource(publicEvent, map)).isEqualTo(publicOrders);
+        assertThat(source.resolveTableFromSource(inventoryEvent, map)).isEqualTo(inventoryOrders);
+    }
+
+    @Test
+    public void shouldReturnNullForRowsWithoutSource() throws Exception {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        Map<String, TableId> map = new HashMap<>();
+        map.put("public.orders", new TableId("testdb", "public", "orders"));
+
+        // Resolved-timestamp rows have no source block; routing returns null (handled by caller).
+        assertThat(source.resolveTableFromSource("{\"resolved\":\"1700000000000000000.0000000000\"}", map)).isNull();
+        // Unknown table is not in the map.
+        assertThat(source.resolveTableFromSource(
+                "{\"op\":\"c\",\"source\":{\"schema_name\":\"public\",\"table_name\":\"unknown\"}}", map)).isNull();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEmbeddedSinklessIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEmbeddedSinklessIT.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.engine.ChangeEvent;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.format.Json;
+
+/**
+ * Proves a fully <b>Kafka-free</b> pipeline: the CockroachDB connector running in sinkless mode under
+ * the Debezium <b>embedded engine</b> ({@link DebeziumEngine}) with file-based offsets and an
+ * in-process change consumer. There is no Kafka and no Kafka Connect runtime anywhere -- only a
+ * CockroachDB container. Change events flow CockroachDB SQL stream -> connector -> embedded consumer.
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBEmbeddedSinklessIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBEmbeddedSinklessIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String DATABASE_NAME = "embedded_sinkless_db";
+    private static final String TABLE_NAME = "embedded_orders";
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION));
+
+    private Connection connection;
+    private Path offsetFile;
+    private DebeziumEngine<ChangeEvent<String, String>> engine;
+    private ExecutorService executor;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+                Statement stmt = defaultConn.createStatement()) {
+            stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME
+                    + " (id INT PRIMARY KEY, customer_name STRING NOT NULL, amount DECIMAL(10,2))");
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Alice', 100.00), (2, 'Bob', 200.50)");
+        }
+
+        offsetFile = Files.createTempFile("embedded-sinkless-offsets", ".dat");
+        Files.deleteIfExists(offsetFile);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (engine != null) {
+            engine.close();
+        }
+        if (executor != null) {
+            executor.shutdownNow();
+            executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+        if (offsetFile != null) {
+            Files.deleteIfExists(offsetFile);
+        }
+    }
+
+    @Test
+    public void shouldReplicateWithoutKafkaViaEmbeddedEngine() throws Exception {
+        List<ChangeEvent<String, String>> received = new CopyOnWriteArrayList<>();
+
+        Properties props = new Properties();
+        props.setProperty("name", "embedded-sinkless");
+        props.setProperty("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        // No Kafka, no Connect cluster: offsets live in a local file.
+        props.setProperty("offset.storage", "org.apache.kafka.connect.storage.FileOffsetBackingStore");
+        props.setProperty("offset.storage.file.filename", offsetFile.toString());
+        props.setProperty("offset.flush.interval.ms", "1000");
+
+        props.setProperty("database.hostname", cockroachdb.getHost());
+        props.setProperty("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        props.setProperty("database.user", cockroachdb.getUsername());
+        props.setProperty("database.password", cockroachdb.getPassword());
+        props.setProperty("database.dbname", DATABASE_NAME);
+        props.setProperty("database.sslmode", "disable");
+        props.setProperty("database.server.name", "embedded-sinkless");
+        props.setProperty("topic.prefix", "embedded");
+
+        // The whole point: sinkless source, so CockroachDB never touches Kafka either.
+        props.setProperty("cockroachdb.changefeed.sink.type", "sinkless");
+        props.setProperty("cockroachdb.changefeed.include.diff", "true");
+        props.setProperty("cockroachdb.changefeed.resolved.interval", "5s");
+        props.setProperty("snapshot.mode", "initial");
+
+        engine = DebeziumEngine.create(Json.class)
+                .using(props)
+                .notifying((ChangeEvent<String, String> record) -> received.add(record))
+                .build();
+        executor = Executors.newSingleThreadExecutor();
+        executor.execute(engine);
+        LOGGER.info("Embedded engine started (no Kafka, no Connect)");
+
+        // Wait for the initial-scan reads of the two seeded rows.
+        waitUntil(() -> received.size() >= 2, 60);
+        assertThat(received.size())
+                .as("Embedded engine should deliver the 2 seeded rows from the sinkless changefeed")
+                .isGreaterThanOrEqualTo(2);
+
+        // The engine is confirmed live; produce DML and confirm it streams through too.
+        int before = received.size();
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (3, 'Carol', 320.00)");
+            stmt.execute("UPDATE " + TABLE_NAME + " SET amount = 150.00 WHERE id = 1");
+        }
+        waitUntil(() -> received.size() > before, 60);
+
+        LOGGER.info("Embedded engine received {} change events with no Kafka in the pipeline", received.size());
+        assertThat(received.size())
+                .as("Embedded engine should deliver live DML over the sinkless changefeed without Kafka")
+                .isGreaterThan(before);
+
+        // Every delivered event carries a real value payload (the Debezium envelope as JSON).
+        boolean hasEnvelope = received.stream()
+                .map(ChangeEvent::value)
+                .filter(v -> v != null)
+                .anyMatch(v -> v.contains("\"op\""));
+        assertThat(hasEnvelope)
+                .as("Delivered events should carry the Debezium envelope JSON")
+                .isTrue();
+    }
+
+    private static void waitUntil(BooleanSupplier condition, int maxSeconds) throws InterruptedException {
+        for (int i = 0; i < maxSeconds && !condition.getAsBoolean(); i++) {
+            Thread.sleep(1000);
+        }
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSinklessIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSinklessIT.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * End-to-end integration test for the connector's <b>sinkless</b> changefeed delivery mode
+ * ({@code cockroachdb.changefeed.sink.type=sinkless}).
+ *
+ * <p>Unlike the kafka mode, a sinkless (core) changefeed streams change events back over the
+ * connector's own SQL connection, so there is <b>no intermediate Kafka</b> at all. This test
+ * therefore starts only CockroachDB (no Kafka container), runs the connector task in sinkless
+ * mode with <b>no sink URI</b>, produces DML, and asserts Debezium {@link SourceRecord}s come out
+ * of {@code poll()}. It is the key validation that pgjdbc streams the never-ending sinkless
+ * result set rather than buffering it.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBSinklessIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSinklessIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String DATABASE_NAME = "sinkless_testdb";
+    private static final String TABLE_NAME = "sinkless_orders";
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION));
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
+            try (Statement stmt = defaultConn.createStatement()) {
+                stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+            }
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT PRIMARY KEY, "
+                    + "customer_name STRING NOT NULL, "
+                    + "amount DECIMAL(10,2), "
+                    + "status STRING DEFAULT 'PENDING'"
+                    + ")");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldStreamSinklessChangefeedOverSqlWithoutKafka() throws Exception {
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "sinkless-cockroachdb-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "sinkless-test");
+        config.put("topic.prefix", "sinkless-test");
+
+        // Sinkless mode: change events stream back over the SQL connection. No sink URI, no
+        // intermediate Kafka, no consumer security to configure.
+        config.put("cockroachdb.changefeed.sink.type", "sinkless");
+        config.put("cockroachdb.changefeed.include.diff", "true");
+        config.put("cockroachdb.changefeed.resolved.interval", "5s");
+        // snapshot.mode=initial -> the sinkless changefeed runs initial_scan='yes', so rows that
+        // exist before the connector starts are emitted deterministically (op='r'). This avoids the
+        // cursor=now race where DML produced before the changefeed is actually capturing would be
+        // missed: a core changefeed is not visible in SHOW CHANGEFEED JOBS, so there is no reliable
+        // external readiness signal; instead the test waits until the initial-scan reads arrive.
+        config.put("snapshot.mode", "initial");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        // Seed rows BEFORE starting the connector so the initial scan captures them with no race.
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Alice', 100.00, 'PENDING')");
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (2, 'Bob', 200.50, 'PROCESSING')");
+        }
+        LOGGER.info("Seeded 2 rows before connector start (captured by initial_scan)");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+        LOGGER.info("Task initialized, starting in sinkless mode...");
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+                LOGGER.error("Task start failed: {}", e.getMessage(), e);
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        if (taskError.get() != null) {
+            LOGGER.error("Task failed to start", taskError.get());
+        }
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+
+        // Phase 1: the initial scan streams the two seeded rows as reads (op='r'). Receiving them
+        // proves the sinkless changefeed streams over SQL AND that the changefeed is now live, with
+        // no reliance on a racy external readiness signal.
+        List<SourceRecord> allRecords = new ArrayList<>();
+        long initialReads = pollUntil(allRecords, 60,
+                () -> countOp(allRecords, "r") >= 2);
+        LOGGER.info("Initial scan delivered {} read (op='r') records over the sinkless stream", initialReads);
+        assertThat(countOp(allRecords, "r"))
+                .as("Sinkless initial scan should deliver the 2 seeded rows as op='r' reads")
+                .isGreaterThanOrEqualTo(2L);
+
+        // Phase 2: the changefeed is confirmed live, so DML produced now is captured deterministically
+        // (no cursor race). This exercises the long-lived streaming cursor that the EOF fix enables.
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (3, 'Carol', 320.00, 'NEW')");
+            stmt.execute("UPDATE " + TABLE_NAME + " SET status = 'COMPLETED' WHERE id = 1");
+            stmt.execute("DELETE FROM " + TABLE_NAME + " WHERE id = 2");
+        }
+        LOGGER.info("Produced live DML after the changefeed was confirmed streaming");
+
+        pollUntil(allRecords, 60, () -> countOp(allRecords, "c") >= 1);
+        LOGGER.info("Sinkless test collected {} total SourceRecords", allRecords.size());
+
+        for (SourceRecord record : allRecords) {
+            assertThat(record.topic()).isNotNull();
+            assertThat(record.sourcePartition()).isNotNull();
+            assertThat(record.sourceOffset()).isNotNull();
+        }
+
+        // The live INSERT must arrive as a create (op='c'), proving the unbounded cursor keeps
+        // streaming changes after the initial scan rather than stalling or being torn down.
+        assertThat(countOp(allRecords, "c"))
+                .as("Connector should deliver the live create (op='c') event over the sinkless stream")
+                .isGreaterThanOrEqualTo(1L);
+    }
+
+    /**
+     * Polls the task until {@code done} is satisfied or {@code maxAttempts} elapse, accumulating
+     * records into {@code sink}. Returns the number of records collected.
+     */
+    private long pollUntil(List<SourceRecord> sink, int maxAttempts, BooleanSupplier done)
+            throws InterruptedException {
+        for (int i = 0; i < maxAttempts && !done.getAsBoolean(); i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null && !records.isEmpty()) {
+                    sink.addAll(records);
+                    LOGGER.info("Poll attempt {}: received {} records (total: {})",
+                            i + 1, records.size(), sink.size());
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            catch (Exception e) {
+                LOGGER.warn("Poll attempt {} failed: {}", i + 1, e.getMessage());
+            }
+            Thread.sleep(1000);
+        }
+        return sink.size();
+    }
+
+    private static long countOp(List<SourceRecord> records, String op) {
+        return records.stream()
+                .map(SourceRecord::value)
+                .filter(v -> v instanceof Struct)
+                .map(v -> (Struct) v)
+                .filter(s -> s.schema().field("op") != null)
+                .map(s -> s.getString("op"))
+                .filter(op::equals)
+                .count();
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(
+                                                                                Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2024

Problem

The connector requires an intermediate Kafka cluster: the changefeed pushes change events into intermediate topics and the connector runs a separate consumer to read them back. That consumer is an additional client to secure and operate, and some deployments do not want a second Kafka dependency in the ingestion path.

Change

Add an opt-in sinkless delivery mode selected with cockroachdb.changefeed.sink.type=sinkless. The connector creates a core changefeed with CREATE CHANGEFEED FOR TABLE and no INTO clause and streams change events directly over a dedicated SQL connection, including the changefeed message key so delete events carry their primary key. The Debezium output topics and envelope are identical to kafka mode; only the ingestion path differs. The kafka mode remains the default and is unchanged. The README documents both modes and the durability tradeoff: sinkless resume after downtime is bounded by the gc.ttlseconds window because there is no intermediate buffer. A second commit adds an integration test that runs the connector in sinkless mode inside the Debezium embedded engine, with no Kafka or Kafka Connect in the pipeline.

Verification

Unit tests cover the sinkless changefeed query construction, source-block table routing, and config validation. CockroachDBSinklessIT exercises the full sinkless flow against real CockroachDB, including an initial-scan read and a live change over the long-lived cursor, and CockroachDBEmbeddedSinklessIT runs the connector Kafka-free under the embedded engine. Full unit suite 234 tests green and integration suite 45 tests green on CockroachDB v25.4.13, cloud connection suite green, and the crdb-to-sinkless and crdb-to-crdb-embedded example pipelines run end to end with this build.