### PR TITLE
debezium/dbz#2277 Validate the diff option when reusing an existing changefeed

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -389,6 +389,21 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                                     + "The CockroachDB connector can only consume the enriched envelope. Drop or recreate that "
                                     + "changefeed with envelope='enriched' (and full_table_name), or use a different topic prefix.");
                         }
+                        // Changefeed options are fixed at creation time, so a reused changefeed that
+                        // lacks the diff option can never deliver the before images the configuration
+                        // promises. Fail fast instead of silently emitting updates without them.
+                        if (config.isChangefeedIncludeDiff() && !changefeedHasDiffOption(description)) {
+                            throw new IllegalStateException("Found an existing running changefeed for table " + table
+                                    + " using topic prefix '" + topicPrefix + "' that was created without the diff option, but "
+                                    + "cockroachdb.changefeed.include.diff is enabled. Update events from that changefeed cannot "
+                                    + "carry a before image. Cancel the changefeed job and restart the connector so it recreates "
+                                    + "the changefeed with diff, or disable cockroachdb.changefeed.include.diff.");
+                        }
+                        if (!config.isChangefeedIncludeDiff() && changefeedHasDiffOption(description)) {
+                            LOGGER.warn("Reusing changefeed for table {} that was created with the diff option while "
+                                    + "cockroachdb.changefeed.include.diff is disabled; update events will carry before images.",
+                                    table);
+                        }
                         return true;
                     }
                 }
@@ -407,6 +422,32 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * so this guards reuse of a pre-existing changefeed. Whitespace is normalized because the
      * description may render the option as {@code envelope = 'enriched'} or {@code envelope='enriched'}.
      */
+    /**
+     * Returns {@code true} if a {@code SHOW CHANGEFEED JOBS} description lists the {@code diff}
+     * option. Only the option list inside {@code WITH OPTIONS (...)} is inspected, so table names
+     * that contain the word diff do not match.
+     */
+    static boolean changefeedHasDiffOption(String description) {
+        if (description == null) {
+            return false;
+        }
+        int start = description.indexOf("WITH OPTIONS (");
+        if (start < 0) {
+            return false;
+        }
+        String options = description.substring(start + "WITH OPTIONS (".length());
+        int end = options.lastIndexOf(')');
+        if (end >= 0) {
+            options = options.substring(0, end);
+        }
+        for (String option : options.split(",")) {
+            if ("diff".equals(option.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     static boolean changefeedUsesEnrichedEnvelope(String description) {
         if (description == null) {
             return false;

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangefeedReuseTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangefeedReuseTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the changefeed reuse option checks. CockroachDB fixes changefeed options at
+ * creation time, so a reused changefeed must be validated against the connector configuration;
+ * silently reusing a changefeed without the {@code diff} option while
+ * {@code cockroachdb.changefeed.include.diff} is enabled leaves update events without a before
+ * image.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBChangefeedReuseTest {
+
+    private static final String WITH_DIFF = "CREATE CHANGEFEED FOR TABLE reprodb.public.acct INTO 'kafka://kafka:9092?topic_prefix=repro.' "
+            + "WITH OPTIONS (diff, enriched_properties = 'source,schema', envelope = 'enriched', resolved = '3s')";
+    private static final String WITHOUT_DIFF = "CREATE CHANGEFEED FOR TABLE reprodb.public.acct INTO 'kafka://kafka:9092?topic_prefix=repro.' "
+            + "WITH OPTIONS (enriched_properties = 'source,schema', envelope = 'enriched', resolved = '3s')";
+
+    @Test
+    void detectsDiffOptionInJobDescription() {
+        assertThat(CockroachDBStreamingChangeEventSource.changefeedHasDiffOption(WITH_DIFF)).isTrue();
+    }
+
+    @Test
+    void detectsMissingDiffOptionInJobDescription() {
+        assertThat(CockroachDBStreamingChangeEventSource.changefeedHasDiffOption(WITHOUT_DIFF)).isFalse();
+    }
+
+    @Test
+    void diffCheckDoesNotMatchTableNamesContainingDiff() {
+        String description = "CREATE CHANGEFEED FOR TABLE demodb.public.diff_audit INTO 'kafka://kafka:9092?topic_prefix=crdb.' "
+                + "WITH OPTIONS (envelope = 'enriched', resolved = '3s')";
+        assertThat(CockroachDBStreamingChangeEventSource.changefeedHasDiffOption(description)).isFalse();
+    }
+
+    @Test
+    void diffCheckHandlesNullAndMalformedDescriptions() {
+        assertThat(CockroachDBStreamingChangeEventSource.changefeedHasDiffOption(null)).isFalse();
+        assertThat(CockroachDBStreamingChangeEventSource.changefeedHasDiffOption("not a changefeed description")).isFalse();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBChangefeedReuseDiffIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBChangefeedReuseDiffIT.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * Integration test for changefeed reuse option validation.
+ *
+ * <p>CockroachDB fixes changefeed options at creation time. When the connector finds an
+ * existing changefeed for its tables and topic prefix that was created without the {@code diff}
+ * option while {@code cockroachdb.changefeed.include.diff} is enabled, it must fail with a
+ * clear message instead of silently reusing a changefeed that can never deliver before
+ * images.</p>
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBChangefeedReuseDiffIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBChangefeedReuseDiffIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
+    private static final String DATABASE_NAME = "reuse_diff_testdb";
+    private static final String TABLE_NAME = "reuse_events";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
+            try (Statement stmt = defaultConn.createStatement()) {
+                stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+            }
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT8 PRIMARY KEY, "
+                    + "name STRING NOT NULL"
+                    + ")");
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'Alice')");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        stopTask();
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldFailFastWhenReusedChangefeedLacksDiffOption() throws Exception {
+        // First run creates the changefeed without the diff option.
+        startTask(connectorConfig(false));
+        assertThat(pollUntilRecordsOrError(30).records).as("First run should stream the seed row").isNotEmpty();
+        stopTask();
+
+        // Second run enables include.diff; the connector finds the existing no-diff changefeed
+        // and must refuse to reuse it.
+        startTask(connectorConfig(true));
+        PollOutcome outcome = pollUntilRecordsOrError(45);
+        assertThat(outcome.error)
+                .as("Second run should fail instead of silently reusing the no-diff changefeed")
+                .isNotNull();
+        assertThat(outcome.error.getMessage() + " " + rootCauseMessage(outcome.error))
+                .contains("diff");
+    }
+
+    private static String rootCauseMessage(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null) {
+            cur = cur.getCause();
+        }
+        return cur.getMessage() == null ? "" : cur.getMessage();
+    }
+
+    private static final class PollOutcome {
+        final List<SourceRecord> records = new ArrayList<>();
+        Throwable error;
+    }
+
+    private PollOutcome pollUntilRecordsOrError(int attempts) throws InterruptedException {
+        PollOutcome outcome = new PollOutcome();
+        for (int i = 0; i < attempts; i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null) {
+                    for (SourceRecord r : records) {
+                        if (r.topic() != null && !r.topic().contains("__debezium-heartbeat")) {
+                            outcome.records.add(r);
+                        }
+                    }
+                }
+            }
+            catch (Throwable t) {
+                outcome.error = t;
+                return outcome;
+            }
+            if (!outcome.records.isEmpty()) {
+                return outcome;
+            }
+            Thread.sleep(1000);
+        }
+        return outcome;
+    }
+
+    private Map<String, String> connectorConfig(boolean includeDiff) {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "reuse-diff-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "reuse-test");
+        config.put("topic.prefix", "reuse-test");
+        config.put("table.include.list", "public." + TABLE_NAME);
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.enriched.properties", "source,schema");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("cockroachdb.changefeed.resolved.interval", "2s");
+        config.put("snapshot.mode", "initial");
+        config.put("heartbeat.interval.ms", "1000");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+        if (includeDiff) {
+            config.put("cockroachdb.changefeed.include.diff", "true");
+        }
+        return config;
+    }
+
+    private void startTask(Map<String, String> config) throws Exception {
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+    }
+
+    private void stopTask() {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+            task = null;
+        }
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(
+                                                                                java.util.Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEmbeddedSinklessIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBEmbeddedSinklessIT.java
@@ -47,7 +47,7 @@ public class CockroachDBEmbeddedSinklessIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBEmbeddedSinklessIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "embedded_sinkless_db";
     private static final String TABLE_NAME = "embedded_orders";
 

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSinklessIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBSinklessIT.java
@@ -55,7 +55,7 @@ public class CockroachDBSinklessIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBSinklessIT.class);
 
-    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.10");
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
     private static final String DATABASE_NAME = "sinkless_testdb";
     private static final String TABLE_NAME = "sinkless_orders";
 


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2277

Problem

CockroachDB fixes changefeed options at creation time, and the connector reuses an existing changefeed that matches its tables and topic prefix while checking only the envelope option. A changefeed created before cockroachdb.changefeed.include.diff was enabled keeps running without the diff option, the configuration is silently ineffective, and update events arrive without a before image, mixed with before-carrying events from any diff-enabled changefeed writing to the same topics. Reproduced on a live pipeline: redeploying with include.diff enabled reused the same changefeed job and updates continued without full before images.

Change

Check the diff option in the changefeed job description during reuse. When include.diff is enabled and the changefeed lacks the option, fail with a message naming the remediation, matching the existing behavior for a mismatched envelope. When the changefeed has diff but include.diff is disabled, log a warning and reuse it. Also update two integration test fallback literals from v25.4.10 to the current v25.4.13 pin.

Verification

Reproduced the silent reuse before the change and observed the fail-fast message after it on the same pipeline; the cancel-and-restart remediation then restored full before images end to end. Unit tests cover the option check, including a table name containing the word diff. A new integration test creates a changefeed without diff and asserts the second connector run fails. Full unit suite 238 tests green, integration suite 46 tests green on v25.4.13, cloud connection suite green, and the crdb-to-crdb example pipeline runs end to end.