### PR TITLE
debezium/dbz#2278 Add cockroachdb.changefeed.kafka.sink.config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Example connector configuration:
 | `cockroachdb.changefeed.sink.topic.prefix`   | ""       | Prefix for intermediate topic names, used verbatim: topics are `<prefix><database>.<schema>.<table>`. Include your own separator (e.g. `crdb.`). If empty, defaults to `<topic.prefix>.` |
 | `cockroachdb.changefeed.max.tables.per.changefeed` | 0  | Max tables per changefeed. `0` = all in one. Set positive to split large table sets across multiple changefeeds and avoid per-table coupling |
 | `cockroachdb.changefeed.sink.options`        | ""       | Additional sink options in key=value format   |
+| `cockroachdb.changefeed.kafka.sink.config`   | -        | JSON for CockroachDB's `kafka_sink_config` changefeed option, e.g. `{"Flush": {"Messages": 100, "Frequency": "500ms"}}`. Tunes changefeed-to-Kafka flush batching (delivery latency). Kafka mode only |
 | `cockroachdb.changefeed.resolved.interval`   | 10s      | Resolved timestamp interval                   |
 | `cockroachdb.changefeed.include.updated`     | false    | Include updated column information            |
 | `cockroachdb.changefeed.include.diff`        | false    | Include before/after diff information         |

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -23,6 +23,7 @@ import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.connector.cockroachdb.serialization.ChangefeedJsonMapper;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -374,6 +375,33 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withImportance(Importance.LOW)
             .withDescription("Additional options for the sink in key=value format, comma-separated. "
                     + "Example: 'compression=gzip,retry_count=3'");
+
+    public static final Field CHANGEFEED_KAFKA_SINK_CONFIG = Field.create("cockroachdb.changefeed.kafka.sink.config")
+            .withDisplayName("Changefeed kafka sink config")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withWidth(Width.LONG)
+            .withImportance(Importance.LOW)
+            .withValidation(CockroachDBConnectorConfig::validateKafkaSinkConfig)
+            .withDescription("JSON value for the CockroachDB kafka_sink_config changefeed option, which tunes "
+                    + "how the changefeed batches and flushes writes to the intermediate Kafka sink. "
+                    + "Example: {\"Flush\": {\"Messages\": 100, \"Frequency\": \"500ms\"}}. "
+                    + "Only used when cockroachdb.changefeed.sink.type is kafka.");
+
+    private static int validateKafkaSinkConfig(Configuration config, Field field, Field.ValidationOutput problems) {
+        String value = config.getString(field);
+        if (value == null || value.trim().isEmpty()) {
+            return 0;
+        }
+        try {
+            ChangefeedJsonMapper.create().readTree(value);
+            return 0;
+        }
+        catch (Exception e) {
+            problems.accept(field, value, "must be a valid JSON document");
+            return 1;
+        }
+    }
 
     public static final Field CHANGEFEED_SINK_TLS_CA_CERT_FILE = Field.create("cockroachdb.changefeed.sink.tls.ca.cert.file")
             .withDisplayName("Changefeed sink CA certificate file")
@@ -1095,6 +1123,10 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     public String getChangefeedSinkOptions() {
         return config.getString(CHANGEFEED_SINK_OPTIONS);
+    }
+
+    public String getChangefeedKafkaSinkConfig() {
+        return config.getString(CHANGEFEED_KAFKA_SINK_CONFIG);
     }
 
     // Connection-related configuration getters

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -988,6 +988,12 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         if (sinkOptions != null && !sinkOptions.trim().isEmpty()) {
             options.add(sanitizeLiteral(sinkOptions));
         }
+        // kafka_sink_config takes a JSON document as a quoted SQL literal; the value is
+        // validated as JSON at configuration time and internal single quotes are doubled here.
+        String kafkaSinkConfig = config.getChangefeedKafkaSinkConfig();
+        if (kafkaSinkConfig != null && !kafkaSinkConfig.trim().isEmpty()) {
+            options.add("kafka_sink_config='" + sanitizeLiteral(kafkaSinkConfig) + "'");
+        }
         return String.join(", ", options);
     }
 

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBKafkaSinkConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBKafkaSinkConfigTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.TableId;
+
+/**
+ * Unit tests for the {@code cockroachdb.changefeed.kafka.sink.config} property, which passes
+ * CockroachDB's {@code kafka_sink_config} changefeed option through to the generated
+ * {@code CREATE CHANGEFEED} statement. The value is a JSON document and must be emitted as a
+ * single-quoted SQL literal; the general sink options passthrough cannot carry it because it
+ * escapes the required quotes.
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBKafkaSinkConfigTest {
+
+    private static final String FLUSH_CONFIG = "{\"Flush\": {\"Messages\": 100, \"Frequency\": \"500ms\"}}";
+
+    private CockroachDBStreamingChangeEventSource source(Configuration config) {
+        return new CockroachDBStreamingChangeEventSource(new CockroachDBConnectorConfig(config), null, null, null, null);
+    }
+
+    private Configuration.Builder baseConfig() {
+        return Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("database.server.name", "test")
+                .with("topic.prefix", "crdb")
+                .with("cockroachdb.changefeed.sink.type", "kafka")
+                .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+    }
+
+    @Test
+    void appendsKafkaSinkConfigAsQuotedLiteral() {
+        Configuration config = baseConfig()
+                .with("cockroachdb.changefeed.kafka.sink.config", FLUSH_CONFIG)
+                .build();
+        String query = source(config).buildSinkChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders")), null, false);
+        assertThat(query).contains("kafka_sink_config='" + FLUSH_CONFIG + "'");
+    }
+
+    @Test
+    void omitsKafkaSinkConfigWhenUnset() {
+        String query = source(baseConfig().build()).buildSinkChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders")), null, false);
+        assertThat(query).doesNotContain("kafka_sink_config");
+    }
+
+    @Test
+    void escapesSingleQuotesInsideJsonValues() {
+        Configuration config = baseConfig()
+                .with("cockroachdb.changefeed.kafka.sink.config", "{\"Flush\": {\"Frequency\": \"1s\"}, \"note\": \"o'brien\"}")
+                .build();
+        String query = source(config).buildSinkChangefeedQuery(
+                List.of(new TableId("testdb", "public", "orders")), null, false);
+        assertThat(query).contains("o''brien");
+        assertThat(query).doesNotContain("o'brien'}");
+    }
+
+    @Test
+    void rejectsValuesThatAreNotJson() {
+        Configuration config = baseConfig()
+                .with("cockroachdb.changefeed.kafka.sink.config", "not json at all")
+                .build();
+        CockroachDBConnectorConfig connectorConfig = new CockroachDBConnectorConfig(config);
+        assertThat(connectorConfig.validateAndRecord(
+                List.of(CockroachDBConnectorConfig.CHANGEFEED_KAFKA_SINK_CONFIG), s -> {
+                })).isFalse();
+    }
+}

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBKafkaSinkConfigIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBKafkaSinkConfigIT.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.common.metrics.PluginMetrics;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import io.debezium.connector.cockroachdb.CockroachDBConnectorTask;
+
+/**
+ * Integration test for the {@code cockroachdb.changefeed.kafka.sink.config} property: the JSON
+ * value must reach CockroachDB as the {@code kafka_sink_config} changefeed option.
+ *
+ * @author Virag Tripathi
+ */
+@Testcontainers
+public class CockroachDBKafkaSinkConfigIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBKafkaSinkConfigIT.class);
+
+    private static final String COCKROACHDB_VERSION = System.getProperty("cockroachdb.version", "v25.4.13");
+    private static final String DATABASE_NAME = "sinkcfg_testdb";
+    private static final String TABLE_NAME = "sinkcfg_events";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final KafkaContainer kafka = new KafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.4.0"))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("kafka");
+
+    @Container
+    private static final CockroachContainer cockroachdb = new CockroachContainer(
+            DockerImageName.parse("cockroachdb/cockroach:" + COCKROACHDB_VERSION))
+            .withNetwork(NETWORK)
+            .withNetworkAliases("cockroachdb");
+
+    private Connection connection;
+    private CockroachDBConnectorTask task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        kafka.start();
+        cockroachdb.start();
+
+        String defaultJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/defaultdb");
+        try (Connection defaultConn = DriverManager.getConnection(
+                defaultJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword())) {
+            try (Statement stmt = defaultConn.createStatement()) {
+                stmt.execute("CREATE DATABASE IF NOT EXISTS " + DATABASE_NAME);
+            }
+        }
+
+        String testJdbcUrl = cockroachdb.getJdbcUrl().replace("/postgres", "/" + DATABASE_NAME);
+        connection = DriverManager.getConnection(testJdbcUrl, cockroachdb.getUsername(), cockroachdb.getPassword());
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET CLUSTER SETTING kv.rangefeed.enabled = true");
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+                    + "id INT8 PRIMARY KEY, "
+                    + "name STRING NOT NULL"
+                    + ")");
+        }
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (task != null) {
+            try {
+                task.stop();
+            }
+            catch (Exception e) {
+                LOGGER.warn("Error stopping task: {}", e.getMessage());
+            }
+        }
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldCreateChangefeedWithKafkaSinkConfig() throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("INSERT INTO " + TABLE_NAME + " VALUES (1, 'seed')");
+        }
+
+        startTask();
+
+        List<SourceRecord> initial = pollForRecords(r -> true, 1, 45);
+        assertThat(initial).as("Should receive the seed row").isNotEmpty();
+
+        try (Statement stmt = connection.createStatement();
+                var rs = stmt.executeQuery("SELECT description FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running'")) {
+            boolean found = false;
+            while (rs.next()) {
+                String description = rs.getString(1);
+                if (description != null && description.contains("kafka_sink_config")) {
+                    LOGGER.info("Changefeed description: {}", description);
+                    found = true;
+                }
+            }
+            assertThat(found)
+                    .as("The running changefeed must carry the kafka_sink_config option")
+                    .isTrue();
+        }
+    }
+
+    private void startTask() throws Exception {
+        String hostBootstrap = kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", "");
+
+        Map<String, String> config = new HashMap<>();
+        config.put("name", "sink-config-test");
+        config.put("connector.class", "io.debezium.connector.cockroachdb.CockroachDBConnector");
+        config.put("database.hostname", cockroachdb.getHost());
+        config.put("database.port", String.valueOf(cockroachdb.getMappedPort(26257)));
+        config.put("database.user", cockroachdb.getUsername());
+        config.put("database.password", cockroachdb.getPassword());
+        config.put("database.dbname", DATABASE_NAME);
+        config.put("database.sslmode", "disable");
+        config.put("database.server.name", "sinkcfg-test");
+        config.put("topic.prefix", "sinkcfg-test");
+        config.put("table.include.list", "public." + TABLE_NAME);
+        config.put("cockroachdb.changefeed.sink.type", "kafka");
+        config.put("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+        config.put("cockroachdb.changefeed.kafka.bootstrap.servers", hostBootstrap);
+        config.put("cockroachdb.changefeed.enriched.properties", "source,schema");
+        config.put("cockroachdb.changefeed.kafka.auto.offset.reset", "earliest");
+        config.put("cockroachdb.changefeed.kafka.poll.timeout.ms", "1000");
+        config.put("cockroachdb.changefeed.resolved.interval", "2s");
+        config.put("snapshot.mode", "initial");
+        config.put("heartbeat.interval.ms", "1000");
+        config.put("cockroachdb.changefeed.kafka.sink.config", "{\"Flush\": {\"Messages\": 100, \"Frequency\": \"500ms\"}}");
+        config.put("offset.storage", "org.apache.kafka.connect.storage.MemoryOffsetBackingStore");
+
+        task = new CockroachDBConnectorTask();
+        task.initialize(createMockContext());
+
+        AtomicReference<Throwable> taskError = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(1);
+        Thread taskThread = new Thread(() -> {
+            try {
+                task.start(config);
+                started.countDown();
+            }
+            catch (Throwable e) {
+                taskError.set(e);
+                started.countDown();
+            }
+        });
+        taskThread.setDaemon(true);
+        taskThread.start();
+
+        boolean didStart = started.await(30, TimeUnit.SECONDS);
+        assertThat(didStart).as("Task should start within 30 seconds").isTrue();
+        assertThat(taskError.get()).as("Task should start without error").isNull();
+    }
+
+    private interface RecordFilter {
+        boolean test(SourceRecord record);
+    }
+
+    private List<SourceRecord> pollForRecords(RecordFilter filter, int minimum, int attempts) throws Exception {
+        List<SourceRecord> collected = new ArrayList<>();
+        for (int i = 0; i < attempts; i++) {
+            try {
+                List<SourceRecord> records = task.poll();
+                if (records != null) {
+                    for (SourceRecord r : records) {
+                        if (r.topic() != null && !r.topic().contains("__debezium-heartbeat") && filter.test(r)) {
+                            collected.add(r);
+                        }
+                    }
+                }
+            }
+            catch (Exception e) {
+                LOGGER.warn("Poll failed: {}", e.getMessage());
+            }
+            if (collected.size() >= minimum) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        return collected;
+    }
+
+    private SourceTaskContext createMockContext() {
+        return new SourceTaskContext() {
+            @Override
+            public Map<String, String> configs() {
+                return new HashMap<>();
+            }
+
+            @Override
+            public OffsetStorageReader offsetStorageReader() {
+                return new OffsetStorageReader() {
+                    @Override
+                    public <T> Map<String, Object> offset(Map<String, T> partition) {
+                        return null;
+                    }
+
+                    @Override
+                    public <T> Map<Map<String, T>, Map<String, Object>> offsets(
+                                                                                java.util.Collection<Map<String, T>> partitions) {
+                        return new HashMap<>();
+                    }
+                };
+            }
+
+            @Override
+            public PluginMetrics pluginMetrics() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2278

Problem

CockroachDB batches kafka sink writes, and the changefeed's kafka_sink_config option tunes flush behavior, for example Flush settings for message count and frequency to bound delivery latency. The connector cannot pass this option today: cockroachdb.changefeed.sink.options escapes single quotes, and kafka_sink_config requires a single-quoted JSON literal, so the generated CREATE CHANGEFEED statement is invalid. Verified on v25.4.13: the option works when written directly and fails through the passthrough.

Change

Add cockroachdb.changefeed.kafka.sink.config, validated as JSON at configuration time and appended to the generated CREATE CHANGEFEED statement as a properly quoted literal with internal single quotes escaped, in kafka mode only. Document the property in the README.

Verification

Unit tests cover the generated statement, quoting including single quotes inside JSON string values, omission when unset, and rejection of non-JSON values. A new integration test starts the connector with the option against real CockroachDB and Kafka and asserts the running changefeed job description carries kafka_sink_config. Full unit suite 242 tests green and integration suite 47 tests green on v25.4.13, cloud connection suite green. One unrelated flaky failure of CockroachDBRestartResumeIT in a full-suite run passed on isolated rerun and on a full-suite rerun.