### PR TITLE
debezium/dbz#2283 Include the message key in the streaming dedup identifier

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -781,7 +781,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 return;
             }
 
-            String eventId = createEventId(table, jsonNode);
+            String eventId = createEventId(table, jsonNode, keyJson);
             if (eventId != null && processedEvents.putIfAbsent(eventId, Boolean.TRUE) != null) {
                 LOGGER.debug("Skipping duplicate event: {}", eventId);
                 return;
@@ -835,21 +835,28 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
 
     /**
      * Creates a unique event identifier for deduplication.
-     * <p>The key combines the schema-qualified {@link TableId} with the operation type
-     * and the event's nanosecond timestamp. The table identity is taken from the
-     * {@code TableId} (derived from the Kafka topic the event arrived on), not from the
-     * message body: the changefeed {@code source.table_name} field is unqualified, so two
-     * same-named tables in different schemas (for example {@code public.orders} and
-     * {@code inventory.orders}) that change at the same MVCC timestamp would otherwise
-     * collide and have one event silently dropped. Using the {@code TableId} also removes
-     * any dependency on the {@code source} enriched property being present.
+     * <p>The identifier combines the schema-qualified {@link TableId} with the operation
+     * type, the event's nanosecond timestamp, and the changefeed message key. The table
+     * identity is taken from the {@code TableId} (derived from the Kafka topic the event
+     * arrived on), not from the message body: the changefeed {@code source.table_name}
+     * field is unqualified, so two same-named tables in different schemas (for example
+     * {@code public.orders} and {@code inventory.orders}) that change at the same MVCC
+     * timestamp would otherwise collide and have one event silently dropped. Using the
+     * {@code TableId} also removes any dependency on the {@code source} enriched property
+     * being present.
+     * <p>The message key is required to tell apart different rows that share an operation
+     * and timestamp: two rows changed in the same transaction can carry the same
+     * {@code ts_ns}, and without the key one of the two events is silently discarded as a
+     * duplicate (debezium/dbz#2283). A missing key degrades to table, operation and
+     * timestamp only.
      */
-    static String createEventId(TableId table, JsonNode jsonNode) {
+    static String createEventId(TableId table, JsonNode jsonNode, String keyJson) {
         try {
             JsonNode payloadNode = resolvePayload(jsonNode);
             String operation = payloadNode.path("op").asText("");
             String timestamp = payloadNode.path("ts_ns").asText("");
-            return table.identifier() + ":" + operation + ":" + timestamp;
+            String rowKey = keyJson == null ? "" : keyJson.trim();
+            return table.identifier() + ":" + operation + ":" + timestamp + ":" + rowKey;
         }
         catch (Exception e) {
             return null;

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBEventDeduplicationTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBEventDeduplicationTest.java
@@ -47,8 +47,8 @@ public class CockroachDBEventDeduplicationTest {
         JsonNode publicEvent = event("c", "1749572623476416439", "orders");
         JsonNode inventoryEvent = event("c", "1749572623476416439", "orders");
 
-        String publicId = CockroachDBStreamingChangeEventSource.createEventId(publicOrders, publicEvent);
-        String inventoryId = CockroachDBStreamingChangeEventSource.createEventId(inventoryOrders, inventoryEvent);
+        String publicId = CockroachDBStreamingChangeEventSource.createEventId(publicOrders, publicEvent, "[1]");
+        String inventoryId = CockroachDBStreamingChangeEventSource.createEventId(inventoryOrders, inventoryEvent, "[1]");
 
         assertThat(publicId).isNotNull();
         assertThat(inventoryId).isNotNull();
@@ -56,22 +56,39 @@ public class CockroachDBEventDeduplicationTest {
     }
 
     @Test
-    public void shouldProduceStableIdForSameTableOpAndTimestamp() throws Exception {
+    public void shouldDistinguishDifferentRowsSharingOpAndTimestamp() throws Exception {
+        // Two rows changed in the same transaction share op and ts_ns. Reproduced live with the
+        // bank workload (debezium/dbz#2283): a transfer updates two accounts in one transaction,
+        // and the second event was dropped as a duplicate, losing the row change.
+        TableId bank = new TableId("bank", "public", "bank");
+        JsonNode firstRow = event("u", "1784905282711794397", "bank");
+        JsonNode secondRow = event("u", "1784905282711794397", "bank");
+
+        String firstId = CockroachDBStreamingChangeEventSource.createEventId(bank, firstRow, "[871]");
+        String secondId = CockroachDBStreamingChangeEventSource.createEventId(bank, secondRow, "[883]");
+
+        assertThat(firstId).isNotNull();
+        assertThat(secondId).isNotNull();
+        assertThat(firstId).isNotEqualTo(secondId);
+    }
+
+    @Test
+    public void shouldProduceStableIdForSameTableOpTimestampAndKey() throws Exception {
         TableId orders = new TableId("demodb", "public", "orders");
         JsonNode first = event("u", "100", "orders");
         JsonNode second = event("u", "100", "orders");
 
-        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, first))
-                .isEqualTo(CockroachDBStreamingChangeEventSource.createEventId(orders, second));
+        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, first, "[1]"))
+                .isEqualTo(CockroachDBStreamingChangeEventSource.createEventId(orders, second, "[1]"));
     }
 
     @Test
     public void shouldDistinguishByOperationAndTimestamp() throws Exception {
         TableId orders = new TableId("demodb", "public", "orders");
 
-        String create = CockroachDBStreamingChangeEventSource.createEventId(orders, event("c", "100", "orders"));
-        String update = CockroachDBStreamingChangeEventSource.createEventId(orders, event("u", "100", "orders"));
-        String laterUpdate = CockroachDBStreamingChangeEventSource.createEventId(orders, event("u", "200", "orders"));
+        String create = CockroachDBStreamingChangeEventSource.createEventId(orders, event("c", "100", "orders"), "[1]");
+        String update = CockroachDBStreamingChangeEventSource.createEventId(orders, event("u", "100", "orders"), "[1]");
+        String laterUpdate = CockroachDBStreamingChangeEventSource.createEventId(orders, event("u", "200", "orders"), "[1]");
 
         assertThat(create).isNotEqualTo(update);
         assertThat(update).isNotEqualTo(laterUpdate);
@@ -79,13 +96,24 @@ public class CockroachDBEventDeduplicationTest {
 
     @Test
     public void shouldNotDependOnSourceBlockBeingPresent() throws Exception {
-        // No source block at all: the key still resolves from the TableId, op and ts_ns.
+        // No source block at all: the key still resolves from the TableId, op, ts_ns and row key.
         TableId orders = new TableId("demodb", "public", "orders");
         JsonNode noSource = MAPPER.readTree("{\"op\": \"c\", \"ts_ns\": 100, \"after\": {\"id\": 1}}");
 
-        String id = CockroachDBStreamingChangeEventSource.createEventId(orders, noSource);
+        String id = CockroachDBStreamingChangeEventSource.createEventId(orders, noSource, "[1]");
         assertThat(id).isNotNull();
         assertThat(id).contains(orders.identifier());
+    }
+
+    @Test
+    public void shouldTolerateMissingMessageKey() throws Exception {
+        // A missing key must not fail id creation; dedup degrades to table, op and ts_ns.
+        TableId orders = new TableId("demodb", "public", "orders");
+        JsonNode event = event("c", "100", "orders");
+
+        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, event, null))
+                .isEqualTo(CockroachDBStreamingChangeEventSource.createEventId(orders, event, null));
+        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, event, null)).isNotNull();
     }
 
     @Test
@@ -95,8 +123,8 @@ public class CockroachDBEventDeduplicationTest {
         JsonNode nested = MAPPER.readTree("{\"payload\": {\"op\": \"c\", \"ts_ns\": 100, \"after\": {\"id\": 1}}}");
         JsonNode flat = MAPPER.readTree("{\"op\": \"c\", \"ts_ns\": 100, \"after\": {\"id\": 1}}");
 
-        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, nested))
-                .isEqualTo(CockroachDBStreamingChangeEventSource.createEventId(orders, flat));
+        assertThat(CockroachDBStreamingChangeEventSource.createEventId(orders, nested, "[1]"))
+                .isEqualTo(CockroachDBStreamingChangeEventSource.createEventId(orders, flat, "[1]"));
     }
 
     @Test


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2283

The streaming dedup identifier was built from table, operation, and ts_ns only. Events for different rows can share a ts_ns (observed for two rows updated in the same transaction and for rows emitted during the initial scan), and the second event of such a pair was discarded as a duplicate, silently losing the row change.

The identifier now also includes the changefeed message key, so only redeliveries of the same row event are deduplicated. A missing key falls back to the previous behavior.

Verification: reproduced live with cockroach workload bank (v25.4.13) through the crdb-to-crdb example pipeline. Before the fix, 4002 changefeed events produced 3999 output records; the 3 missing events were exactly the second members of the 3 (op, ts_ns) collision pairs, and the target converged to a stale balance (sum(balance) 721 instead of 0). With the fix the same workload reaches exact row-count and total-balance parity. 244 unit tests and 47 integration tests pass, plus the crdb-to-crdb (with bank workload), crdb-to-crdb-mtls, and crdb-to-sinkless example demos and the cloud connection IT (6/6) against CockroachDB Cloud.