### PR TITLE
debezium/dbz#2285 Retry the whole 08 class, 57P01, and 40003 at connect time

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/connection/CockroachDBConnection.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/connection/CockroachDBConnection.java
@@ -30,11 +30,10 @@ public class CockroachDBConnection extends JdbcConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBConnection.class);
 
     private static final String SERIALIZATION_FAILURE = "40001";
+    private static final String STATEMENT_COMPLETION_UNKNOWN = "40003";
     private static final String DEADLOCK_DETECTED = "40P01";
-    private static final String CONNECTION_FAILURE = "08000";
-    private static final String CONNECTION_DOES_NOT_EXIST = "08003";
-    private static final String CONNECTION_FAILURE_DURING_EXECUTION = "08006";
-    private static final String COMMUNICATION_LINK_FAILURE = "08S01";
+    private static final String ADMIN_SHUTDOWN = "57P01";
+    private static final String CONNECTION_EXCEPTION_CLASS_PREFIX = "08";
 
     private final CockroachDBConnectorConfig connectorConfig;
 
@@ -205,16 +204,27 @@ public class CockroachDBConnection extends JdbcConnection {
         return identifier;
     }
 
-    private static boolean isTransientError(SQLException e) {
+    /**
+     * Classifies a connect-time failure as transient (retried up to
+     * {@code connection.max.retries} times) or permanent.
+     *
+     * <p>The whole SQL state class 08 (connection exception) is transient by prefix:
+     * pgjdbc raises 08001 for both connection-refused and unknown-host failures, so
+     * enumerating individual members misses the most common transient connect error
+     * (debezium/dbz#2285). 57P01 (admin_shutdown) is raised while a node drains during a
+     * rolling restart. 40001, 40P01, and 40003 are CockroachDB's retryable transaction
+     * states; 40003 (statement_completion_unknown) is safe to retry here because nothing
+     * is in flight at connection establishment.</p>
+     */
+    static boolean isTransientError(SQLException e) {
         String sqlState = e.getSQLState();
         if (sqlState == null) {
             return false;
         }
         return SERIALIZATION_FAILURE.equals(sqlState)
+                || STATEMENT_COMPLETION_UNKNOWN.equals(sqlState)
                 || DEADLOCK_DETECTED.equals(sqlState)
-                || CONNECTION_FAILURE.equals(sqlState)
-                || CONNECTION_DOES_NOT_EXIST.equals(sqlState)
-                || CONNECTION_FAILURE_DURING_EXECUTION.equals(sqlState)
-                || COMMUNICATION_LINK_FAILURE.equals(sqlState);
+                || ADMIN_SHUTDOWN.equals(sqlState)
+                || sqlState.startsWith(CONNECTION_EXCEPTION_CLASS_PREFIX);
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/connection/CockroachDBConnectionTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/connection/CockroachDBConnectionTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.cockroachdb.connection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -199,5 +200,38 @@ public class CockroachDBConnectionTest {
 
         assertThat(tcpKeepAliveConnection).isNotNull();
         assertThat(tcpKeepAliveConfig.isTcpKeepAlive()).isTrue();
+    }
+
+    @Test
+    public void shouldClassifyRetryableTransactionStatesAsTransient() {
+        // 40001 serialization_failure, 40P01 deadlock_detected, 40003 statement_completion_unknown
+        // (ambiguous result; safe to retry at connection establishment where nothing is in flight).
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("retry", "40001"))).isTrue();
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("deadlock", "40P01"))).isTrue();
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("ambiguous", "40003"))).isTrue();
+    }
+
+    @Test
+    public void shouldClassifyWholeConnectionExceptionClassAsTransient() {
+        // pgjdbc raises 08001 for both connection-refused and unknown-host (debezium/dbz#2285),
+        // so the whole 08 class must be transient, not an enumerated subset.
+        for (String state : new String[]{ "08000", "08001", "08003", "08004", "08006", "08007", "08P01", "08S01" }) {
+            assertThat(CockroachDBConnection.isTransientError(new SQLException("conn", state)))
+                    .as("SQL state %s", state)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void shouldClassifyNodeShutdownAsTransient() {
+        // 57P01 admin_shutdown is raised while a CockroachDB node drains during a rolling restart.
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("draining", "57P01"))).isTrue();
+    }
+
+    @Test
+    public void shouldNotClassifyNonTransientStatesAsTransient() {
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("syntax", "42601"))).isFalse();
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("auth", "28P01"))).isFalse();
+        assertThat(CockroachDBConnection.isTransientError(new SQLException("no state", (String) null))).isFalse();
     }
 }


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2285

The connection-establishment retry loop classified transient errors by enumerating SQL states 40001, 40P01, 08000, 08003, 08006, and 08S01. pgjdbc raises 08001 for both connection-refused and unknown-host failures (verified against postgresql 42.7.7), so the most common transient connect failure was not retried and the connector failed immediately instead of honoring connection.max.retries.

The classifier now treats the whole 08 connection-exception class as transient by prefix and adds 57P01 (admin_shutdown, raised while a node drains) and 40003 (statement_completion_unknown, safe to retry at connection establishment where nothing is in flight). Runtime errors are unaffected; they already reach the connector error handler and retry via task restart.

Verification: 248 unit tests (4 new classification tests covering every 08 member, 57P01, 40003, and non-transient states) and 47 integration tests pass; crdb-to-crdb example demo with the bank workload reaches exact row-count and total-balance parity; cloud connection IT 6/6 against CockroachDB Cloud.