### PR TITLE
debezium/dbz#2289 Wire the agent argLine through surefire and add JaCoCo reporting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,3 +55,9 @@ jobs:
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Maven build CockroachDB
         run: ./cockroachdb/mvnw clean install -f cockroachdb/pom.xml -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -DfailFlakyTests=false -Ddebezium.test.records.waittime=5
+      - name: Upload JaCoCo coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacoco-coverage-report
+          path: cockroachdb/target/site/jacoco/
+          retention-days: 90

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
 
         <cockroachdb.version>v25.4.13</cockroachdb.version>
         <version.jmh>1.37</version.jmh>
+        <version.jacoco>0.8.12</version.jacoco>
+        <!-- Overridden by the JaCoCo agent at runtime; empty so plain builds are unaffected. -->
+        <argLine></argLine>
     </properties>
 
     <dependencyManagement>
@@ -320,10 +323,41 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- Preserve the parent argLine and append the agent argLine (JaCoCo and
+                         similar tooling); without the passthrough the unit-test JVM silently
+                         runs without the agent and coverage reports only integration data. -->
+                    <argLine>-Djava.awt.headless=true ${debug.argline} ${modules.argline} ${mockito.argLine} @{argLine}</argLine>
                     <systemPropertyVariables>
                         <cockroachdb.version>${cockroachdb.version}</cockroachdb.version>
                     </systemPropertyVariables>
                 </configuration>
+            </plugin>
+            <!-- Informational code coverage: run with ./mvnw verify jacoco:report and read
+                 target/site/jacoco/index.html. No enforcement threshold. -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${version.jacoco}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>io/debezium/connector/cockroachdb/benchmark/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Failsafe for integration test lifecycle -->
             <plugin>
@@ -331,7 +365,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <skipTests>${skipITs}</skipTests>
-                    <argLine>${argLine}</argLine>
+                    <argLine>@{argLine}</argLine>
                     <systemPropertyVariables>
                         <cockroachdb.version>${cockroachdb.version}</cockroachdb.version>
                         <cockroachdb.host>localhost</cockroachdb.host>


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2289

The pom passed the argLine property to failsafe but not surefire, and used early-binding interpolation, so agent-based tooling silently skipped the unit-test JVM and coverage reported integration data only. Both test plugins now use surefire late binding (@{argLine}) with an empty default property, preserving the parent argLine. Adds the JaCoCo plugin with an informational report bound to verify (no enforcement threshold), JMH benchmark package excluded. Read the report at target/site/jacoco/index.html after ./mvnw verify.

Verification: 248 unit tests and 47 integration tests pass; the in-pom report reproduces the manually measured baseline exactly (86.0 percent line, 65.4 percent branch, benchmarks excluded) with both test JVMs contributing.