### PR TITLE
debezium/dbz#2303 Register the kafka.sink.config property in the ConfigDef

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -526,6 +526,7 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     CHANGEFEED_SINK_URI,
                     CHANGEFEED_SINK_TOPIC_PREFIX,
                     CHANGEFEED_SINK_OPTIONS,
+                    CHANGEFEED_KAFKA_SINK_CONFIG,
                     CHANGEFEED_KAFKA_CONSUMER_GROUP_PREFIX,
                     CHANGEFEED_KAFKA_POLL_TIMEOUT_MS,
                     CHANGEFEED_KAFKA_AUTO_OFFSET_RESET,

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -551,4 +551,25 @@ public class CockroachDBConnectorConfigTest {
             return new CockroachDBConnectorConfig(delegate.build());
         }
     }
+
+    @Test
+    public void shouldExposeEveryDeclaredFieldInConfigDef() throws Exception {
+        // Every Field constant declared on this connector's config class must be registered in
+        // the ConfigDef the connector reports to Kafka Connect; an unregistered field still
+        // works at runtime but is invisible to REST validation and configuration UIs
+        // (debezium/dbz#2303). Inherited core fields are excluded: core owns which of its
+        // fields the shared ConfigDefinition exposes, and peer connectors match that.
+        ConfigDef configDef = new CockroachDBConnector().config();
+        for (java.lang.reflect.Field member : CockroachDBConnectorConfig.class.getDeclaredFields()) {
+            if (member.getType() == io.debezium.config.Field.class
+                    && java.lang.reflect.Modifier.isPublic(member.getModifiers())
+                    && java.lang.reflect.Modifier.isStatic(member.getModifiers())) {
+                io.debezium.config.Field field = (io.debezium.config.Field) member.get(null);
+                assertThat(configDef.names())
+                        .as("Field constant %s (%s) must be registered in the ConfigDef",
+                                member.getName(), field.name())
+                        .contains(field.name());
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2303

The cockroachdb.changefeed.kafka.sink.config property worked at runtime but was never added to the CONFIG_DEFINITION field groups, so the ConfigDef the connector reports to Kafka Connect omitted it and REST validation and configuration UIs did not list it. Adds the field to the changefeed group plus a regression test asserting every Field constant declared on the config class is registered in the ConfigDef, so the next added option cannot repeat this.

The sweep deliberately excludes inherited core fields: core owns which of its fields the shared ConfigDefinition exposes, and peer connectors match that (poll.dispatch.interval.ms is unregistered in core for every connector, verified against the shipped debezium-core).

Verification: 238 unit tests (1 new) and 47 integration tests pass.