### PR TITLE
debezium/dbz#2310 Decode BYTES values and honor binary.handling.mode

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitter.java
@@ -198,7 +198,10 @@ public class CockroachDBChangeRecordEmitter extends RelationalChangeRecordEmitte
                 return node.isNumber() ? node.decimalValue().toPlainString() : node.asText();
             case "BYTEA":
             case "BYTES":
-                return node.asText();
+            case "BLOB":
+                // Changefeeds encode bytes as the bytea hex literal ("\x01ff"); decode so the
+                // value satisfies the Connect BYTES schema instead of failing validation.
+                return CockroachDBValueConverterProvider.decodeBytesLiteral(node.asText());
             case "TIMESTAMP":
             case "TIMESTAMP WITHOUT TIME ZONE":
                 return CockroachDBTemporalConversions.parseTimestampMicros(node.asText());

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorTask.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorTask.java
@@ -86,7 +86,7 @@ public class CockroachDBConnectorTask extends BaseSourceTask<CockroachDBPartitio
         // Service providers
         registerServiceProviders(connectorConfig.getServiceRegistry());
 
-        CockroachDBValueConverterProvider valueConverter = new CockroachDBValueConverterProvider();
+        CockroachDBValueConverterProvider valueConverter = new CockroachDBValueConverterProvider(connectorConfig.binaryHandlingMode());
         schema = new CockroachDBSchema(taskContext, topicNamingStrategy, valueConverter);
         try {
             schema.initialize(connectorConfig);

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProvider.java
@@ -5,8 +5,10 @@
  */
 package io.debezium.connector.cockroachdb;
 
+import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.Base64;
 import java.util.Locale;
 
 import org.apache.kafka.connect.data.Field;
@@ -15,6 +17,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.data.Json;
 import io.debezium.data.vector.DoubleVector;
 import io.debezium.relational.Column;
@@ -42,6 +45,16 @@ import io.debezium.time.ZonedTimestamp;
 public class CockroachDBValueConverterProvider implements ValueConverterProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CockroachDBValueConverterProvider.class);
+
+    private final BinaryHandlingMode binaryMode;
+
+    public CockroachDBValueConverterProvider() {
+        this(BinaryHandlingMode.BYTES);
+    }
+
+    public CockroachDBValueConverterProvider(BinaryHandlingMode binaryMode) {
+        this.binaryMode = binaryMode == null ? BinaryHandlingMode.BYTES : binaryMode;
+    }
 
     @Override
     public SchemaBuilder schemaBuilder(Column column) {
@@ -100,11 +113,12 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             case "NAME":
                 return SchemaBuilder.string().optional();
 
-            // Binary
+            // Binary: the schema type follows binary.handling.mode, matching the other
+            // Debezium relational connectors (bytes, or a base64/hex string).
             case "BYTEA":
             case "BYTES":
             case "BLOB":
-                return SchemaBuilder.bytes().optional();
+                return binaryMode.getSchema().optional();
 
             // Date/time types -- schema names match the Debezium time logical types so downstream
             // consumers (and the JDBC sink) interpret them the same as other Debezium connectors.
@@ -290,6 +304,41 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
                     }
                 };
 
+            // Binary types: accept decoded bytes from the emitter or the raw changefeed hex
+            // literal, and emit per binary.handling.mode.
+            case "BYTEA":
+            case "BYTES":
+            case "BLOB":
+                return value -> {
+                    if (value == null) {
+                        return null;
+                    }
+                    byte[] bytes;
+                    if (value instanceof byte[]) {
+                        bytes = (byte[]) value;
+                    }
+                    else if (value instanceof ByteBuffer) {
+                        bytes = ((ByteBuffer) value).array();
+                    }
+                    else {
+                        bytes = decodeBytesLiteral(value.toString());
+                        if (bytes == null) {
+                            return null;
+                        }
+                    }
+                    switch (binaryMode) {
+                        case BASE64:
+                            return Base64.getEncoder().encodeToString(bytes);
+                        case BASE64_URL_SAFE:
+                            return Base64.getUrlEncoder().encodeToString(bytes);
+                        case HEX:
+                            return toHex(bytes);
+                        case BYTES:
+                        default:
+                            return ByteBuffer.wrap(bytes);
+                    }
+                };
+
             // JSON types -- pass through as string
             case "JSON":
             case "JSONB":
@@ -298,5 +347,51 @@ public class CockroachDBValueConverterProvider implements ValueConverterProvider
             default:
                 return value -> value != null ? value.toString() : null;
         }
+    }
+
+    /**
+     * Decodes the bytea literal that CockroachDB changefeeds use for BYTES values
+     * ({@code \x} followed by hex digits). Returns null for values that do not parse,
+     * after logging them, so a malformed value degrades to a null field instead of
+     * failing the event.
+     */
+    public static byte[] decodeBytesLiteral(String text) {
+        if (text == null) {
+            return null;
+        }
+        if (text.startsWith("\\x") || text.startsWith("\\X")) {
+            String hex = text.substring(2);
+            if (hex.length() % 2 != 0) {
+                LOGGER.warn("Cannot decode bytes literal with odd hex length: {} characters", hex.length());
+                return null;
+            }
+            byte[] bytes = new byte[hex.length() / 2];
+            try {
+                for (int i = 0; i < bytes.length; i++) {
+                    bytes[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+                }
+            }
+            catch (NumberFormatException e) {
+                LOGGER.warn("Cannot decode bytes literal: {}", e.getMessage());
+                return null;
+            }
+            return bytes;
+        }
+        try {
+            // Fallback for base64-encoded payloads produced by non-enriched encoders.
+            return Base64.getDecoder().decode(text);
+        }
+        catch (IllegalArgumentException e) {
+            LOGGER.warn("Cannot decode bytes value as hex literal or base64: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBChangeRecordEmitterTest.java
@@ -202,4 +202,48 @@ public class CockroachDBChangeRecordEmitterTest {
                 new CockroachDBPartition("test"), offsetContext, Clock.system(),
                 connectorConfig, table, Envelope.Operation.DELETE, null, null, keyNode);
     }
+
+    // ---------------------------------------------------------------------------------------
+    // BYTES regression (debezium/dbz#2310): enriched changefeeds encode BYTES as the bytea
+    // hex literal ("\\x01ff", captured from v25.4.13). The extracted value must be the
+    // decoded bytes, or Connect rejects the String against the BYTES schema and the field
+    // is emitted as null.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void bytesValuesDecodeFromChangefeedHexLiteral() throws Exception {
+        JsonNode node = new ObjectMapper().readTree(
+                "{\"taxlot_id\": \"\\\\xf925e84ec3444ce383785556b60dd048\", \"parent_id\": \"\\\\x01ff\", \"empty\": \"\\\\x\"}");
+        List<Column> columns = List.of(
+                column("taxlot_id", "BYTES", Types.BINARY),
+                column("parent_id", "BYTEA", Types.BINARY),
+                column("empty", "BYTES", Types.BINARY));
+
+        Object[] values = CockroachDBChangeRecordEmitter.extractColumnValues(node, columns);
+
+        assertThat(values[0]).isInstanceOf(byte[].class);
+        assertThat((byte[]) values[0]).containsExactly(
+                0xf9, 0x25, 0xe8, 0x4e, 0xc3, 0x44, 0x4c, 0xe3, 0x83, 0x78, 0x55, 0x56, 0xb6, 0x0d, 0xd0, 0x48);
+        assertThat((byte[]) values[1]).containsExactly(0x01, 0xff);
+        assertThat((byte[]) values[2]).isEmpty();
+    }
+
+    @Test
+    public void deleteKeyWithBytesPrimaryKeyDecodesToBytes() throws Exception {
+        Table table = Table.editor()
+                .tableId(new TableId("demodb", "public", "tax_cost_basis"))
+                .addColumn(Column.editor().name("taxlot_id").type("BYTES").jdbcType(Types.BINARY).optional(false).create())
+                .addColumn(Column.editor().name("note").type("STRING").jdbcType(Types.VARCHAR).optional(true).create())
+                .setPrimaryKeyNames("taxlot_id")
+                .create();
+        JsonNode keyNode = ChangefeedJsonMapper.create()
+                .readTree("{\"taxlot_id\": \"\\\\x01ff\"}");
+
+        CockroachDBChangeRecordEmitter emitter = emitter(table, keyNode);
+
+        Object[] oldValues = emitter.getOldColumnValues();
+        assertThat(oldValues).isNotNull();
+        assertThat(oldValues[0]).isInstanceOf(byte[].class);
+        assertThat((byte[]) oldValues[0]).containsExactly(0x01, 0xff);
+    }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBValueConverterProviderTest.java
@@ -423,4 +423,48 @@ public class CockroachDBValueConverterProviderTest {
         assertThat(tableSchema.valueSchema().type()).isEqualTo(Schema.Type.STRUCT);
         return tableSchema;
     }
+
+    // ---------------------------------------------------------------------------------------
+    // Binary handling (debezium/dbz#2310): BYTES columns honor binary.handling.mode in both
+    // the schema mapping and the value conversion. Input can be decoded bytes from the
+    // emitter or the raw changefeed hex literal.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    void bytesSchemaAndConverterFollowBinaryHandlingMode() {
+        Column col = Column.editor().name("b").type("BYTES").jdbcType(Types.BINARY).optional(true).create();
+        byte[] raw = new byte[]{ 0x01, (byte) 0xff };
+
+        CockroachDBValueConverterProvider bytesMode = new CockroachDBValueConverterProvider(
+                io.debezium.config.CommonConnectorConfig.BinaryHandlingMode.BYTES);
+        assertThat(bytesMode.schemaBuilder(col).build().type()).isEqualTo(Schema.Type.BYTES);
+        Object asBytes = bytesMode.converter(col, field(col, bytesMode)).convert(raw);
+        assertThat(asBytes).isInstanceOf(java.nio.ByteBuffer.class);
+        assertThat(((java.nio.ByteBuffer) asBytes).array()).containsExactly(0x01, 0xff);
+
+        CockroachDBValueConverterProvider hexMode = new CockroachDBValueConverterProvider(
+                io.debezium.config.CommonConnectorConfig.BinaryHandlingMode.HEX);
+        assertThat(hexMode.schemaBuilder(col).build().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(hexMode.converter(col, field(col, hexMode)).convert(raw)).isEqualTo("01ff");
+
+        CockroachDBValueConverterProvider base64Mode = new CockroachDBValueConverterProvider(
+                io.debezium.config.CommonConnectorConfig.BinaryHandlingMode.BASE64);
+        assertThat(base64Mode.schemaBuilder(col).build().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(base64Mode.converter(col, field(col, base64Mode)).convert(raw)).isEqualTo("Af8=");
+    }
+
+    @Test
+    void bytesConverterDecodesRawChangefeedLiteral() {
+        // Defensive path: if the raw hex literal reaches the converter, it decodes it too.
+        Column col = Column.editor().name("b").type("BYTES").jdbcType(Types.BINARY).optional(true).create();
+        CockroachDBValueConverterProvider bytesMode = new CockroachDBValueConverterProvider(
+                io.debezium.config.CommonConnectorConfig.BinaryHandlingMode.BYTES);
+        Object converted = bytesMode.converter(col, field(col, bytesMode)).convert("\\x01ff");
+        assertThat(converted).isInstanceOf(java.nio.ByteBuffer.class);
+        assertThat(((java.nio.ByteBuffer) converted).array()).containsExactly(0x01, 0xff);
+    }
+
+    private org.apache.kafka.connect.data.Field field(Column col, CockroachDBValueConverterProvider p) {
+        return new org.apache.kafka.connect.data.Field(col.name(), 0, p.schemaBuilder(col).build());
+    }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBAllTypesIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBAllTypesIT.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.cockroachdb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage of every CockroachDB column type the connector maps, pinned against the
+ * actual enriched changefeed encodings (captured from a real cluster: bytes arrive as bytea
+ * hex literals, JSONB and spatial types as JSON objects, arrays as JSON arrays, VECTOR as a
+ * bracketed string). A conversion regression on any type surfaces here as a null field or a
+ * failed assertion instead of reaching production (debezium/dbz#2310).
+ *
+ * @author Virag Tripathi
+ */
+public class CockroachDBAllTypesIT extends AbstractCockroachDBPipelineIT {
+
+    private Connection connection;
+
+    @AfterEach
+    public void closeConnection() throws Exception {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+        connection = null;
+    }
+
+    @Test
+    public void shouldEmitEveryColumnTypeWithoutNulls() throws Exception {
+        connection = openDatabase("alltypes_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS alltypes ("
+                    + "id INT8 PRIMARY KEY, "
+                    + "c_bytes BYTES NOT NULL, c_bit BIT(4), c_varbit VARBIT, c_interval INTERVAL, c_inet INET, "
+                    + "c_jsonb JSONB, c_uuid UUID, c_dec DECIMAL(10,3), c_float FLOAT8, "
+                    + "c_int_arr INT8[], c_str_arr STRING[], c_dec_arr DECIMAL[], "
+                    + "c_vector VECTOR(3), c_geog GEOGRAPHY, c_geom GEOMETRY, "
+                    + "c_bool BOOL, c_int2 INT2, c_ts TIMESTAMP, c_tstz TIMESTAMPTZ, c_date DATE, c_str STRING)");
+            stmt.execute("UPSERT INTO alltypes VALUES ("
+                    + "1, x'01ff', B'1010', B'011', INTERVAL '1 day 02:03:04.5', '192.168.1.10/24', "
+                    + "'{\"a\": [1,2]}', 'f47ac10b-58cc-4372-a567-0e02b2c3d479', 12.345, 1.5, "
+                    + "ARRAY[1,2,3], ARRAY['x','y'], ARRAY[1.25,2.5], "
+                    + "'[1.5,2.5,3.5]', 'POINT(-74 40.7)', 'LINESTRING(0 0, 1 1)', "
+                    + "true, 7, '2026-06-08 11:01:45.883', '2026-06-08 09:01:45.883+00', '2026-06-08', 'hello')");
+        }
+
+        startTask(baseConnectorConfig("alltypes-test", "alltypes_testdb", "public.alltypes"));
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).as("Should receive the seed row").isNotEmpty();
+
+        Struct after = ((Struct) records.get(0).value()).getStruct("after");
+        assertThat(after).isNotNull();
+
+        // The regression signal for the whole class of encoding bugs: no field of a fully
+        // populated row may arrive null.
+        for (org.apache.kafka.connect.data.Field field : after.schema().fields()) {
+            assertThat(after.get(field)).as("Field %s must not be null", field.name()).isNotNull();
+        }
+
+        Object bytesValue = after.get("c_bytes");
+        byte[] bytes = bytesValue instanceof ByteBuffer ? ((ByteBuffer) bytesValue).array() : (byte[]) bytesValue;
+        assertThat(bytes).containsExactly(0x01, 0xff);
+
+        assertThat(after.getString("c_bit")).isEqualTo("1010");
+        assertThat(after.getString("c_varbit")).isEqualTo("011");
+        assertThat(after.getString("c_interval")).contains("02:03:04");
+        assertThat(after.getString("c_inet")).isEqualTo("192.168.1.10/24");
+        assertThat(after.getString("c_jsonb")).contains("\"a\"");
+        assertThat(after.getString("c_uuid")).isEqualTo("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+        assertThat(after.getString("c_dec")).isEqualTo("12.345");
+        assertThat(after.getFloat64("c_float")).isEqualTo(1.5d);
+        assertThat(after.getString("c_int_arr")).isEqualTo("[1,2,3]");
+        assertThat(after.getString("c_str_arr")).isEqualTo("[\"x\",\"y\"]");
+        assertThat(after.getString("c_dec_arr")).contains("1.25").contains("2.5");
+        assertThat(after.getArray("c_vector")).containsExactly(1.5d, 2.5d, 3.5d);
+        assertThat(after.getString("c_geog")).contains("Point");
+        assertThat(after.getString("c_geom")).contains("LineString");
+        assertThat(after.getBoolean("c_bool")).isTrue();
+        assertThat(after.getInt16("c_int2")).isEqualTo((short) 7);
+        assertThat(after.get("c_ts")).isInstanceOf(Long.class);
+        assertThat(after.getString("c_tstz")).contains("2026-06-08");
+        assertThat(after.get("c_date")).isInstanceOf(Integer.class);
+        assertThat(after.getString("c_str")).isEqualTo("hello");
+
+        // The full envelope must serialize with schemas enabled: this is where a type/value
+        // mismatch would surface downstream.
+        try (JsonConverter jsonConverter = new JsonConverter()) {
+            Map<String, Object> converterConfig = new HashMap<>();
+            converterConfig.put("schemas.enable", "true");
+            converterConfig.put("converter.type", "value");
+            jsonConverter.configure(converterConfig);
+            SourceRecord r = records.get(0);
+            assertThat(jsonConverter.fromConnectData(r.topic(), r.valueSchema(), r.value())).isNotEmpty();
+        }
+    }
+
+    @Test
+    public void shouldRoundTripBytesPrimaryKeyThroughInsertUpdateAndDelete() throws Exception {
+        connection = openDatabase("bytespk_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS taxlots ("
+                    + "taxlot_id BYTES NOT NULL PRIMARY KEY, note STRING NOT NULL)");
+            stmt.execute("UPSERT INTO taxlots VALUES (x'f925e84ec3444ce383785556b60dd048', 'open')");
+        }
+
+        startTask(baseConnectorConfig("bytespk-test", "bytespk_testdb", "public.taxlots"));
+
+        List<SourceRecord> initial = pollForRecords(1, 45);
+        assertThat(initial).as("Should receive the seed row").isNotEmpty();
+        Struct seedKey = (Struct) initial.get(0).key();
+        assertThat(keyBytes(seedKey)).containsExactly(
+                0xf9, 0x25, 0xe8, 0x4e, 0xc3, 0x44, 0x4c, 0xe3, 0x83, 0x78, 0x55, 0x56, 0xb6, 0x0d, 0xd0, 0x48);
+        Struct seedAfter = ((Struct) initial.get(0).value()).getStruct("after");
+        assertThat(seedAfter.get("taxlot_id")).as("BYTES primary key column must not be null in the row image").isNotNull();
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("UPDATE taxlots SET note = 'closed' WHERE taxlot_id = x'f925e84ec3444ce383785556b60dd048'");
+        }
+        List<SourceRecord> updates = pollForRecords(
+                r -> r.value() != null && "u".equals(((Struct) r.value()).getString("op")), 1, 60);
+        assertThat(updates).as("Should receive the update event").isNotEmpty();
+        assertThat(((Struct) updates.get(0).value()).getStruct("after").getString("note")).isEqualTo("closed");
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("DELETE FROM taxlots WHERE taxlot_id = x'f925e84ec3444ce383785556b60dd048'");
+        }
+        List<SourceRecord> deletes = pollForRecords(
+                r -> r.value() != null && "d".equals(((Struct) r.value()).getString("op")), 1, 60);
+        assertThat(deletes).as("Should receive the delete event").isNotEmpty();
+
+        SourceRecord delete = deletes.get(0);
+        assertThat(delete.key()).as("Delete record must carry its BYTES primary key").isNotNull();
+        assertThat(keyBytes((Struct) delete.key())).containsExactly(
+                0xf9, 0x25, 0xe8, 0x4e, 0xc3, 0x44, 0x4c, 0xe3, 0x83, 0x78, 0x55, 0x56, 0xb6, 0x0d, 0xd0, 0x48);
+
+        // The production failure point from the report: key conversion with schemas enabled.
+        try (JsonConverter jsonConverter = new JsonConverter()) {
+            Map<String, Object> converterConfig = new HashMap<>();
+            converterConfig.put("schemas.enable", "true");
+            converterConfig.put("converter.type", "key");
+            jsonConverter.configure(converterConfig);
+            assertThat(jsonConverter.fromConnectData(delete.topic(), delete.keySchema(), delete.key())).isNotEmpty();
+        }
+    }
+
+    private static byte[] keyBytes(Struct key) {
+        Object value = key.get("taxlot_id");
+        assertThat(value).as("taxlot_id in the record key must not be null").isNotNull();
+        return value instanceof ByteBuffer ? ((ByteBuffer) value).array() : (byte[]) value;
+    }
+}


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2310

Enriched changefeeds encode BYTES values as bytea hex literals in both the row image and the message key (verified against CockroachDB v25.4.13 and CockroachDB Cloud). The value converter provider mapped BYTES columns to the Connect BYTES schema but had no converter for them, so the raw string failed Connect validation and the field was emitted as null, including for primary keys. binary.handling.mode had no effect because the schema mapping ignored it.

The emitter now decodes the hex literal to bytes during column extraction, covering row images and the delete key fallback, and the provider follows binary.handling.mode in both the schema mapping and the conversion (bytes, base64, base64-url-safe, hex), matching the other Debezium relational connectors.

An audit of every mapped column type against captured changefeed encodings found no other mismatches. A new all-types integration test pins each encoding end to end (bytes, bit, varbit, interval, inet, jsonb, uuid, decimal, float, arrays, vector, geography, geometry, bool, int2, timestamps, date, string), plus a BYTES primary key through insert, update, and delete including delete key conversion with schemas enabled.

Verification: unit and integration suites pass, the cloud connection tests pass against CockroachDB Cloud, and the changefeed byte encoding was captured and confirmed identical on both a local v25.4.13 cluster and CockroachDB Cloud.