### PR TITLE
debezium/dbz#2319 Warn when a reused changefeed captures removed tables

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -293,7 +293,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         for (List<TableId> group : groups) {
             boolean alreadyRunning = false;
             for (TableId table : group) {
-                if (changefeedExists(connection, table)) {
+                if (changefeedExists(connection, table, tables)) {
                     alreadyRunning = true;
                     break;
                 }
@@ -367,16 +367,17 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * changefeed job description to avoid false positives from changefeeds created by
      * other connector instances targeting the same tables with different topic prefixes.
      */
-    private boolean changefeedExists(CockroachDBConnection connection, TableId table) throws SQLException {
+    private boolean changefeedExists(CockroachDBConnection connection, TableId table, List<TableId> allIncludedTables) throws SQLException {
         String fqTableName = sanitizeIdentifier(table.toString());
         String topicPrefix = resolveTopicPrefix();
         String sinkMarker = "topic_prefix=" + topicPrefix;
 
         try (Statement stmt = connection.connection().createStatement()) {
-            String query = "SELECT description FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running'";
+            String query = "SELECT job_id, description FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running'";
             try (var rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
-                    String description = rs.getString(1);
+                    String jobId = rs.getString(1);
+                    String description = rs.getString(2);
                     if (description != null && description.contains(fqTableName) && description.contains(sinkMarker)) {
                         // A changefeed with our topic prefix already covers this table. The connector
                         // can only consume the enriched envelope, so refuse to reuse one created with a
@@ -403,6 +404,21 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                             LOGGER.warn("Reusing changefeed for table {} that was created with the diff option while "
                                     + "cockroachdb.changefeed.include.diff is disabled; update events will carry before images.",
                                     table);
+                        }
+                        // The captured table set is frozen at job creation. If tables were removed
+                        // from table.include.list since, the reused job keeps streaming them at full
+                        // volume into intermediate topics that nothing consumes.
+                        Set<String> includedIdentifiers = allIncludedTables.stream()
+                                .map(t -> sanitizeIdentifier(t.toString()))
+                                .collect(Collectors.toSet());
+                        List<String> extraTables = findExtraCapturedTables(description, includedIdentifiers);
+                        if (!extraTables.isEmpty()) {
+                            LOGGER.warn("Reused changefeed job {} also captures table(s) {} that are not in "
+                                    + "table.include.list. The job keeps streaming them into intermediate topics that "
+                                    + "this connector does not consume, wasting changefeed work, network, and broker "
+                                    + "storage. To capture only the configured tables, stop the connector, run "
+                                    + "CANCEL JOB {}, and restart the connector so it recreates the changefeed.",
+                                    jobId, extraTables, jobId);
                         }
                         return true;
                     }
@@ -1043,6 +1059,62 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * Sanitizes a SQL identifier by removing characters that are not alphanumeric,
      * underscores, periods, or hyphens.
      */
+    /**
+     * Extracts the table names a changefeed captures from its {@code SHOW CHANGEFEED JOBS}
+     * description. The description echoes the creation statement in the form
+     * {@code CREATE CHANGEFEED FOR TABLE a, TABLE b, ... INTO '...' WITH OPTIONS (...)}
+     * (format captured from a live v25.4 cluster); quotes around individual name parts are
+     * stripped.
+     */
+    static List<String> parseChangefeedTables(String description) {
+        if (description == null) {
+            return List.of();
+        }
+        int forIdx = description.indexOf(" FOR ");
+        int intoIdx = description.indexOf(" INTO ");
+        if (forIdx < 0 || intoIdx < 0 || intoIdx <= forIdx) {
+            return List.of();
+        }
+        String tableList = description.substring(forIdx + 5, intoIdx);
+        List<String> tables = new ArrayList<>();
+        for (String token : tableList.split(",")) {
+            String name = token.trim();
+            if (name.regionMatches(true, 0, "TABLE ", 0, 6)) {
+                name = name.substring(6).trim();
+            }
+            name = name.replace("\"", "");
+            if (!name.isEmpty()) {
+                tables.add(name);
+            }
+        }
+        return tables;
+    }
+
+    /**
+     * Returns the tables a changefeed captures that match none of the included identifiers.
+     * A captured name matches an included identifier when they are equal or when one is a
+     * dot-qualified suffix of the other, so a database-qualified job name matches a
+     * schema-qualified include entry.
+     */
+    static List<String> findExtraCapturedTables(String description, Set<String> includedIdentifiers) {
+        List<String> extras = new ArrayList<>();
+        for (String captured : parseChangefeedTables(description)) {
+            boolean matched = false;
+            for (String included : includedIdentifiers) {
+                if (captured.equals(included)
+                        || captured.endsWith("." + included)
+                        || included.endsWith("." + captured)) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                extras.add(captured);
+            }
+        }
+        return extras;
+    }
+
     private static String sanitizeIdentifier(String identifier) {
         if (identifier == null) {
             return "";

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.cockroachdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -219,5 +220,62 @@ public class CockroachDBStreamingChangeEventSourceTest {
         assertThat(connectorConfig.validateAndRecord(
                 List.of(CockroachDBConnectorConfig.CHANGEFEED_KAFKA_SINK_CONFIG), s -> {
                 })).isFalse();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Reused-changefeed table-set check (debezium/dbz#2319): a reused job frozen at creation
+    // can capture tables that were since removed from table.include.list; the connector must
+    // detect and name them. Description format captured from a real v25.4.13 job.
+    // ---------------------------------------------------------------------------------------
+
+    private static final String MULTI_TABLE_DESCRIPTION = "CREATE CHANGEFEED FOR TABLE fdasbookdbo_account, "
+            + "TABLE journal, TABLE tax_cost_basis INTO 'null://x?topic_prefix=gmf.' "
+            + "WITH OPTIONS (diff, enriched_properties = 'source', envelope = 'enriched', full_table_name, "
+            + "resolved = '10s', updated)";
+
+    @Test
+    public void shouldParseCapturedTablesFromJobDescription() {
+        assertThat(CockroachDBStreamingChangeEventSource.parseChangefeedTables(MULTI_TABLE_DESCRIPTION))
+                .containsExactly("fdasbookdbo_account", "journal", "tax_cost_basis");
+    }
+
+    @Test
+    public void shouldParseQualifiedAndQuotedTableNames() {
+        String description = "CREATE CHANGEFEED FOR TABLE prf1fdasbook.fdasbookdbo.account, "
+                + "TABLE prf1fdasbook.fdasbookdbo.\"order\" INTO 'kafka://k:9092?topic_prefix=x.' WITH OPTIONS (envelope = 'enriched')";
+        assertThat(CockroachDBStreamingChangeEventSource.parseChangefeedTables(description))
+                .containsExactly("prf1fdasbook.fdasbookdbo.account", "prf1fdasbook.fdasbookdbo.order");
+    }
+
+    @Test
+    public void shouldFindTablesTheJobCapturesBeyondTheIncludeList() {
+        Set<String> included = Set.of("fdasbookdbo.account", "fdasbookdbo.journal");
+        assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
+                "CREATE CHANGEFEED FOR TABLE fdasbookdbo.account, TABLE fdasbookdbo.journal, "
+                        + "TABLE fdasbookdbo.tax_cost_basis INTO 'kafka://k' WITH OPTIONS (envelope = 'enriched')",
+                included))
+                .containsExactly("fdasbookdbo.tax_cost_basis");
+    }
+
+    @Test
+    public void shouldFindNoExtrasWhenTheJobMatchesTheIncludeList() {
+        Set<String> included = Set.of("fdasbookdbo.account", "fdasbookdbo.journal");
+        assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
+                "CREATE CHANGEFEED FOR TABLE fdasbookdbo.account, TABLE fdasbookdbo.journal INTO 'kafka://k' "
+                        + "WITH OPTIONS (envelope = 'enriched')",
+                included))
+                .isEmpty();
+    }
+
+    @Test
+    public void shouldMatchIncludedTablesByQualifiedSuffix() {
+        // The job description can carry database-qualified names while the include list uses
+        // schema.table form; qualification differences are not extras.
+        Set<String> included = Set.of("fdasbookdbo.account");
+        assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
+                "CREATE CHANGEFEED FOR TABLE prf1fdasbook.fdasbookdbo.account INTO 'kafka://k' "
+                        + "WITH OPTIONS (envelope = 'enriched')",
+                included))
+                .isEmpty();
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -23,6 +23,12 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import io.debezium.connector.cockroachdb.CockroachDBStreamingChangeEventSource;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
 /**
  * Regression scenarios reproduced from production reports, folded into one class so they share
  * the pipeline stack from {@link AbstractCockroachDBPipelineIT} instead of each booting their
@@ -293,5 +299,40 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
             Thread.sleep(1000);
         }
         return outcome;
+    }
+
+    @Test
+    public void shouldWarnWhenReusedChangefeedCapturesRemovedTables() throws Exception {
+        connection = openDatabase("reuse_extra_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS keep_t (id INT8 PRIMARY KEY, v STRING)");
+            stmt.execute("CREATE TABLE IF NOT EXISTS drop_t (id INT8 PRIMARY KEY, v STRING)");
+            stmt.execute("UPSERT INTO keep_t VALUES (1, 'a')");
+            stmt.execute("UPSERT INTO drop_t VALUES (1, 'a')");
+        }
+
+        // First run creates one changefeed covering both tables.
+        startTask(baseConnectorConfig("reuse-extra-test", "reuse_extra_testdb", "public.keep_t,public.drop_t"));
+        assertThat(pollForRecords(1, 45)).as("First run should stream").isNotEmpty();
+        stopTask();
+
+        // Second run drops drop_t from the include list; the connector reuses the existing
+        // job and must name the table the job still captures (debezium/dbz#2319).
+        Logger sourceLogger = (Logger) org.slf4j.LoggerFactory.getLogger(CockroachDBStreamingChangeEventSource.class);
+        ListAppender<ILoggingEvent> warnings = new ListAppender<>();
+        warnings.start();
+        sourceLogger.addAppender(warnings);
+        try {
+            startTask(baseConnectorConfig("reuse-extra-test", "reuse_extra_testdb", "public.keep_t"));
+            assertThat(pollForRecords(0, 5)).isNotNull();
+            assertThat(warnings.list)
+                    .as("Reuse with a shrunk include list must warn about the extra captured table")
+                    .anyMatch(e -> "WARN".equals(e.getLevel().toString())
+                            && e.getFormattedMessage().contains("drop_t")
+                            && e.getFormattedMessage().contains("CANCEL JOB"));
+        }
+        finally {
+            sourceLogger.detachAppender(warnings);
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2319

The connector reuses a running changefeed when it already covers the configured tables, and the captured table set is frozen at job creation. After tables are removed from table.include.list, the reused job keeps streaming them at full volume into intermediate topics that nothing consumes, silently wasting changefeed work, network, and broker storage.

On reuse, the connector now parses the captured tables from the SHOW CHANGEFEED JOBS description and logs a warning naming the job id, the extra tables, and the remediation: cancel the job and restart the connector so it recreates the changefeed for the configured tables only.

Verification: unit tests cover the description parsing and table-set comparison against a description format captured from a live cluster; a pipeline integration test reproduces the scenario end to end and asserts the warning fires when a table is removed from the include list across a restart. The full unit and integration suites pass.