### PR TITLE
debezium/dbz#2320 Move consumer-override access behind a typed config accessor

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -483,6 +483,22 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withImportance(Importance.LOW)
             .withDescription("Timeout in seconds for validating that an existing JDBC connection is still usable.");
 
+    /**
+     * Prefix for passthrough properties applied to the connector's internal changefeed
+     * Kafka consumer, with the prefix stripped.
+     */
+    public static final String CHANGEFEED_KAFKA_CONSUMER_OVERRIDE_PREFIX = "cockroachdb.changefeed.kafka.consumer.override.";
+
+    /**
+     * Returns the changefeed Kafka consumer passthrough properties as a configuration
+     * subset with {@link #CHANGEFEED_KAFKA_CONSUMER_OVERRIDE_PREFIX} stripped. Typed
+     * facade over the raw configuration, which core plans to stop exposing publicly.
+     */
+    @SuppressWarnings("deprecation")
+    public Configuration getChangefeedKafkaConsumerOverrides() {
+        return getConfig().subset(CHANGEFEED_KAFKA_CONSUMER_OVERRIDE_PREFIX, true);
+    }
+
     private static final ConfigDefinition CONFIG_DEFINITION = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
             .name("CockroachDB")
             .group(Field.Group.CONNECTION,

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -1168,8 +1168,6 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * same passthrough convention Debezium uses for its schema-history and signal Kafka clients. This
      * is the escape hatch for SASL, custom trust/key stores, or overriding any auto-derived value.
      */
-    static final String CONSUMER_OVERRIDE_PREFIX = "cockroachdb.changefeed.kafka.consumer.override.";
-
     /**
      * Kafka SSL store type for inline PEM material. Kafka exposes constants for the SSL config keys
      * (see {@link SslConfigs}) but not for this store-type value, so it is named here. It lets the
@@ -1210,14 +1208,15 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             LOGGER.info("Derived SSL config for the changefeed consumer from cockroachdb.changefeed.sink.tls.* (security.protocol=SSL)");
         }
 
-        Configuration overrides = config.getConfig().subset(CONSUMER_OVERRIDE_PREFIX, true);
+        Configuration overrides = config.getChangefeedKafkaConsumerOverrides();
         int applied = 0;
         for (String key : overrides.keys()) {
             props.put(key, overrides.getString(key));
             applied++;
         }
         if (applied > 0) {
-            LOGGER.info("Applied {} '{}*' property/properties to the changefeed consumer", applied, CONSUMER_OVERRIDE_PREFIX);
+            LOGGER.info("Applied {} '{}*' property/properties to the changefeed consumer", applied,
+                    CockroachDBConnectorConfig.CHANGEFEED_KAFKA_CONSUMER_OVERRIDE_PREFIX);
         }
     }
 

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -572,4 +572,23 @@ public class CockroachDBConnectorConfigTest {
             }
         }
     }
+
+    @Test
+    public void shouldExposeChangefeedConsumerOverridesAsTypedSubset() {
+        Map<String, String> props = new HashMap<>();
+        props.put("database.hostname", "localhost");
+        props.put("database.port", "26257");
+        props.put("database.user", "root");
+        props.put("database.dbname", "testdb");
+        props.put("topic.prefix", "test");
+        props.put("cockroachdb.changefeed.kafka.consumer.override.fetch.max.bytes", "1048576");
+        props.put("cockroachdb.changefeed.kafka.consumer.override.max.poll.records", "1000");
+
+        CockroachDBConnectorConfig config = new CockroachDBConnectorConfig(Configuration.from(props));
+        io.debezium.config.Configuration overrides = config.getChangefeedKafkaConsumerOverrides();
+
+        assertThat(overrides.getString("fetch.max.bytes")).isEqualTo("1048576");
+        assertThat(overrides.getString("max.poll.records")).isEqualTo("1000");
+        assertThat(overrides.keys()).hasSize(2);
+    }
 }


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2320

Debezium core deprecated CommonConnectorConfig.getConfig() in favor of typed accessors on the connector config class and plans to make it protected. The streaming source read the changefeed consumer override subset through the raw configuration, which surfaced as a deprecation warning in the cross version CI build. The prefix constant and subset lookup now live on CockroachDBConnectorConfig as a typed accessor, keeping the single raw-config call inside the config class where the upstream design expects it, so the connector keeps compiling when upstream restricts the raw accessor.

Verification: a unit test covers the accessor and the full unit and integration suites pass. Behavior is unchanged; this is code motion only.