### PR TITLE
debezium/dbz#2322 Never drop events when a schema refresh fails

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
@@ -237,6 +238,14 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             throw new RuntimeException("Failed to stream changes from CockroachDB: " + e.getMessage(), e);
         }
         finally {
+            if (this.schemaRefreshConnection != null) {
+                try {
+                    this.schemaRefreshConnection.close();
+                }
+                catch (Exception e) {
+                    LOGGER.debug("Closing the schema refresh connection failed: {}", e.getMessage());
+                }
+            }
             this.schemaRefreshConnection = null;
             running.set(false);
             LOGGER.info("Stopped CockroachDB streaming change event source");
@@ -816,14 +825,13 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 return;
             }
 
-            // Detect schema changes by comparing event fields against registered columns
-            JsonNode dataNode = !afterNode.isMissingNode() ? afterNode : beforeNode;
-            if (dataNode != null && !dataNode.isMissingNode() && hasSchemaChanged(dataNode, tableObj)) {
+            // Detect schema changes by comparing event fields against registered columns.
+            // Deletes carry {@code after: null} (and no before without the diff option), and
+            // a null row image says nothing about the schema, so it must not be read as
+            // "every column absent" and trigger a refresh per delete (debezium/dbz#2322).
+            JsonNode dataNode = !afterNode.isMissingNode() && !afterNode.isNull() ? afterNode : beforeNode;
+            if (dataNode != null && !dataNode.isMissingNode() && !dataNode.isNull() && hasSchemaChanged(dataNode, tableObj)) {
                 tableObj = refreshTableSchema(table);
-                if (tableObj == null) {
-                    LOGGER.error("Schema refresh failed for table {}, skipping event", table);
-                    return;
-                }
             }
 
             // The changefeed message key carries the primary key columns for every event,
@@ -842,6 +850,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
 
             LOGGER.debug("Dispatching {} event for table {}", operation, table);
             dispatcher.dispatchDataChangeEvent(currentPartition, table, emitter);
+        }
+        catch (DebeziumException e) {
+            // Deliberate failure (for example a schema refresh that failed after reconnect):
+            // propagate so the task restarts and replays the event instead of skipping it.
+            throw e;
         }
         catch (Exception e) {
             LOGGER.error("Error processing changefeed event for table {}: {}",
@@ -1317,18 +1330,54 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * Refreshes the schema for a table by re-querying {@code information_schema}
      * through the persistent connection kept alive during streaming.
      */
-    private io.debezium.relational.Table refreshTableSchema(TableId tableId) {
-        if (schemaRefreshConnection == null) {
-            LOGGER.error("No connection available for schema refresh of table {}", tableId);
-            return null;
-        }
+    io.debezium.relational.Table refreshTableSchema(TableId tableId) {
         try {
-            return schema.refreshTable(schemaRefreshConnection, tableId);
+            return doRefreshTableSchema(tableId);
         }
-        catch (Exception e) {
-            LOGGER.error("Failed to refresh schema for table {}: {}", tableId, e.getMessage(), e);
-            return null;
+        catch (Exception first) {
+            LOGGER.warn("Schema refresh for table {} failed ({}); reconnecting and retrying",
+                    tableId, first.getMessage());
+            try {
+                reconnectSchemaRefreshConnection();
+                return doRefreshTableSchema(tableId);
+            }
+            catch (Exception second) {
+                // Never skip the event: fail the task so the error handler classifies the
+                // SQLException in the cause chain as retriable and the restart replays the
+                // event from the stored consumer position (debezium/dbz#2322).
+                throw new DebeziumException("Schema refresh for table " + tableId
+                        + " failed after reconnecting; failing the task so the event is replayed "
+                        + "instead of skipped", second);
+            }
         }
+    }
+
+    io.debezium.relational.Table doRefreshTableSchema(TableId tableId) throws Exception {
+        if (schemaRefreshConnection == null) {
+            throw new IllegalStateException("No connection available for schema refresh");
+        }
+        return schema.refreshTable(schemaRefreshConnection, tableId);
+    }
+
+    /**
+     * Replaces the long-lived schema refresh connection. Load balancers and proxies close
+     * idle connections underneath the connector, and a schema refresh may be the first use
+     * in minutes, so a failed refresh reconnects before retrying.
+     */
+    void reconnectSchemaRefreshConnection() throws SQLException {
+        CockroachDBConnection old = schemaRefreshConnection;
+        if (old != null) {
+            try {
+                old.close();
+            }
+            catch (Exception e) {
+                LOGGER.debug("Closing the stale schema refresh connection failed: {}", e.getMessage());
+            }
+        }
+        CockroachDBConnection fresh = new CockroachDBConnection(config);
+        fresh.connect();
+        schemaRefreshConnection = fresh;
+        LOGGER.info("Reconnected the schema refresh connection");
     }
 
     @Override

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
@@ -278,4 +278,82 @@ public class CockroachDBStreamingChangeEventSourceTest {
                 included))
                 .isEmpty();
     }
+
+    // ---------------------------------------------------------------------------------------
+    // Schema refresh robustness (debezium/dbz#2322): a failed refresh must reconnect and
+    // retry once, and a persistent failure must fail the task (retriable) instead of
+    // silently skipping the event.
+    // ---------------------------------------------------------------------------------------
+
+    private Configuration refreshTestConfig() {
+        return Configuration.create()
+                .with("database.hostname", "localhost")
+                .with("database.port", "26257")
+                .with("database.user", "root")
+                .with("database.dbname", "testdb")
+                .with("topic.prefix", "crdb")
+                .build();
+    }
+
+    @Test
+    public void shouldReconnectAndRetryWhenSchemaRefreshFails() {
+        TableId table = new TableId("testdb", "public", "orders");
+        io.debezium.relational.Table refreshed = io.debezium.relational.Table.editor()
+                .tableId(table)
+                .addColumn(io.debezium.relational.Column.editor().name("id").type("INT8").create())
+                .create();
+        java.util.concurrent.atomic.AtomicInteger attempts = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.atomic.AtomicInteger reconnects = new java.util.concurrent.atomic.AtomicInteger();
+
+        CockroachDBStreamingChangeEventSource source = new CockroachDBStreamingChangeEventSource(
+                new CockroachDBConnectorConfig(refreshTestConfig()), null, null, null, null) {
+            @Override
+            io.debezium.relational.Table doRefreshTableSchema(TableId tableId) throws Exception {
+                if (attempts.incrementAndGet() == 1) {
+                    throw new java.sql.SQLException("An I/O error occurred while sending to the backend.", "08006");
+                }
+                return refreshed;
+            }
+
+            @Override
+            void reconnectSchemaRefreshConnection() {
+                reconnects.incrementAndGet();
+            }
+        };
+
+        assertThat(source.refreshTableSchema(table)).isSameAs(refreshed);
+        assertThat(attempts.get()).isEqualTo(2);
+        assertThat(reconnects.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldFailRetriablyWhenSchemaRefreshFailsAfterReconnect() {
+        TableId table = new TableId("testdb", "public", "orders");
+        CockroachDBStreamingChangeEventSource source = new CockroachDBStreamingChangeEventSource(
+                new CockroachDBConnectorConfig(refreshTestConfig()), null, null, null, null) {
+            @Override
+            io.debezium.relational.Table doRefreshTableSchema(TableId tableId) throws Exception {
+                throw new java.sql.SQLException("An I/O error occurred while sending to the backend.", "08006");
+            }
+
+            @Override
+            void reconnectSchemaRefreshConnection() {
+            }
+        };
+
+        // The failure must propagate (with the SQLException in the cause chain so the error
+        // handler classifies it retriable) rather than being swallowed into a skipped event.
+        Throwable thrown = org.assertj.core.api.Assertions.catchThrowable(() -> source.refreshTableSchema(table));
+        assertThat(thrown).isNotNull();
+        Throwable cause = thrown;
+        boolean sqlInChain = false;
+        while (cause != null) {
+            if (cause instanceof java.sql.SQLException) {
+                sqlInChain = true;
+                break;
+            }
+            cause = cause.getCause();
+        }
+        assertThat(sqlInChain).as("SQLException must stay in the cause chain for retriable classification").isTrue();
+    }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -335,4 +335,39 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
             sourceLogger.detachAppender(warnings);
         }
     }
+
+    @Test
+    public void shouldNotTriggerSchemaRefreshForDeleteEvents() throws Exception {
+        connection = openDatabase("delete_drift_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS dd_events (id INT8 PRIMARY KEY, v STRING NOT NULL)");
+            stmt.execute("UPSERT INTO dd_events VALUES (7, 'x')");
+        }
+
+        // A delete without a diff image carries after: null; the drift check must not read
+        // that as missing columns and refresh the schema per delete (debezium/dbz#2322).
+        Logger sourceLogger = (Logger) org.slf4j.LoggerFactory.getLogger(CockroachDBStreamingChangeEventSource.class);
+        ListAppender<ILoggingEvent> logs = new ListAppender<>();
+        logs.start();
+        sourceLogger.addAppender(logs);
+        try {
+            startTask(baseConnectorConfig("delete-drift-test", "delete_drift_testdb", "public.dd_events"));
+            assertThat(pollForRecords(1, 45)).as("Should receive the seed row").isNotEmpty();
+
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("DELETE FROM dd_events WHERE id = 7");
+            }
+            List<SourceRecord> deletes = pollForRecords(
+                    r -> r.value() != null && "d".equals(((Struct) r.value()).getString("op")), 1, 60);
+            assertThat(deletes).as("The delete event must arrive").isNotEmpty();
+
+            assertThat(logs.list)
+                    .as("A delete must not trigger a schema-drift refresh")
+                    .noneMatch(e -> e.getFormattedMessage().contains("Schema change detected")
+                            && e.getFormattedMessage().contains("dd_events"));
+        }
+        finally {
+            sourceLogger.detachAppender(logs);
+        }
+    }
 }


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2322

A delete event carries a null row image, and the schema-drift check read it as every registered non-nullable column being absent, triggering a schema refresh round trip on every delete without a diff image. When the long-lived refresh connection had been closed underneath the connector, for example by a load balancer idle timeout, the refresh failed and the event was logged and skipped: silent data loss, reproduced on a five node cluster behind haproxy where the delete existed on the intermediate topic but never reached the output topic.

Three changes: the drift check ignores null or missing row images, a failed refresh reconnects and retries once, and a refresh that still fails raises a retriable failure so the task restarts and replays the event from the stored consumer position instead of skipping it.

Verification: unit tests cover the reconnect retry and the retriable failure semantics; an integration test asserts deletes no longer trigger schema refreshes; the full unit and integration suites pass; and both scenarios were re-run against the same five node haproxy cluster that produced the original failure, confirming the delete now arrives with zero drift detections and that a genuine schema change reconnects the dead refresh connection, retries, and delivers the event with the new column.