### PR TITLE
debezium/dbz#2390 Quote CockroachDB changefeed table identifiers

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -416,7 +416,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                         // The captured table set is frozen at job creation. If tables were removed
                         // from table.include.list since, the reused job keeps streaming them at full
                         // volume into intermediate topics that nothing consumes.
-                        List<String> extraTables = findExtraCapturedTablesForTableIds(description, allIncludedTables);
+                        List<String> extraTables = findExtraCapturedTables(description, allIncludedTables);
                         if (!extraTables.isEmpty()) {
                             LOGGER.warn("Reused changefeed job {} also captures table(s) {} that are not in "
                                     + "table.include.list. The job keeps streaming them into intermediate topics that "
@@ -1162,7 +1162,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 .anyMatch(captured -> qualifiedSuffixMatches(captured, expected));
     }
 
-    private static List<String> findExtraCapturedTablesForTableIds(String description, Collection<TableId> includedTables) {
+    static List<String> findExtraCapturedTables(String description, Collection<TableId> includedTables) {
         List<List<String>> included = includedTables.stream()
                 .map(CockroachDBStreamingChangeEventSource::tableIdComponents)
                 .collect(Collectors.toList());
@@ -1197,31 +1197,6 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             }
         }
         return shared > 0;
-    }
-
-    /**
-     * Returns the tables a changefeed captures that match none of the included identifiers.
-     * A captured name matches an included identifier when they are equal or when one is a
-     * dot-qualified suffix of the other, so a database-qualified job name matches a
-     * schema-qualified include entry.
-     */
-    static List<String> findExtraCapturedTables(String description, Set<String> includedIdentifiers) {
-        List<String> extras = new ArrayList<>();
-        for (String captured : parseChangefeedTables(description)) {
-            boolean matched = false;
-            for (String included : includedIdentifiers) {
-                if (captured.equals(included)
-                        || captured.endsWith("." + included)
-                        || included.endsWith("." + captured)) {
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched) {
-                extras.add(captured);
-            }
-        }
-        return extras;
     }
 
     /**

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -377,7 +377,6 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
      * other connector instances targeting the same tables with different topic prefixes.
      */
     private boolean changefeedExists(CockroachDBConnection connection, TableId table, List<TableId> allIncludedTables) throws SQLException {
-        String fqTableName = sanitizeIdentifier(table.toString());
         String topicPrefix = resolveTopicPrefix();
         String sinkMarker = "topic_prefix=" + topicPrefix;
 
@@ -387,7 +386,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 while (rs.next()) {
                     String jobId = rs.getString(1);
                     String description = rs.getString(2);
-                    if (description != null && description.contains(fqTableName) && description.contains(sinkMarker)) {
+                    if (description != null && descriptionCapturesTable(description, table) && description.contains(sinkMarker)) {
                         // A changefeed with our topic prefix already covers this table. The connector
                         // can only consume the enriched envelope, so refuse to reuse one created with a
                         // different envelope rather than consuming it and failing to parse events. We
@@ -417,10 +416,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                         // The captured table set is frozen at job creation. If tables were removed
                         // from table.include.list since, the reused job keeps streaming them at full
                         // volume into intermediate topics that nothing consumes.
-                        Set<String> includedIdentifiers = allIncludedTables.stream()
-                                .map(t -> sanitizeIdentifier(t.toString()))
-                                .collect(Collectors.toSet());
-                        List<String> extraTables = findExtraCapturedTables(description, includedIdentifiers);
+                        List<String> extraTables = findExtraCapturedTablesForTableIds(description, allIncludedTables);
                         if (!extraTables.isEmpty()) {
                             LOGGER.warn("Reused changefeed job {} also captures table(s) {} that are not in "
                                     + "table.include.list. The job keeps streaming them into intermediate topics that "
@@ -953,7 +949,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         StringBuilder query = new StringBuilder();
         query.append("CREATE CHANGEFEED FOR TABLE ");
         query.append(tables.stream()
-                .map(t -> sanitizeIdentifier(t.toString()))
+                .map(CockroachDBStreamingChangeEventSource::quoteTableId)
                 .collect(Collectors.joining(", ")));
 
         String sinkUri = config.getChangefeedSinkUri();
@@ -980,7 +976,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         StringBuilder query = new StringBuilder();
         query.append("CREATE CHANGEFEED FOR TABLE ");
         query.append(tables.stream()
-                .map(t -> sanitizeIdentifier(t.toString()))
+                .map(CockroachDBStreamingChangeEventSource::quoteTableId)
                 .collect(Collectors.joining(", ")));
         query.append(" WITH ").append(buildChangefeedWithOptions(cursor, hasPriorOffset));
         return query.toString();
@@ -1069,17 +1065,35 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
     }
 
     /**
-     * Sanitizes a SQL identifier by removing characters that are not alphanumeric,
-     * underscores, periods, or hyphens.
+     * Quotes each structured table identifier component independently. Using the {@link TableId}
+     * parts avoids ambiguity when a legal component itself contains a dot, and doubling embedded
+     * quotes follows the PostgreSQL/CockroachDB identifier escaping rules.
      */
+    static String quoteTableId(TableId tableId) {
+        List<String> components = tableIdComponents(tableId);
+        return components.stream()
+                .map(CockroachDBStreamingChangeEventSource::quoteIdentifier)
+                .collect(Collectors.joining("."));
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    }
+
     /**
      * Extracts the table names a changefeed captures from its {@code SHOW CHANGEFEED JOBS}
      * description. The description echoes the creation statement in the form
      * {@code CREATE CHANGEFEED FOR TABLE a, TABLE b, ... INTO '...' WITH OPTIONS (...)}
-     * (format captured from a live v25.4 cluster); quotes around individual name parts are
-     * stripped.
+     * (format captured from a live v25.4 cluster). SQL quotes are parsed rather than blindly
+     * stripped so dots, commas, and escaped quotes inside a component remain intact.
      */
     static List<String> parseChangefeedTables(String description) {
+        return parseChangefeedTableComponents(description).stream()
+                .map(parts -> String.join(".", parts))
+                .collect(Collectors.toList());
+    }
+
+    private static List<List<String>> parseChangefeedTableComponents(String description) {
         if (description == null) {
             return List.of();
         }
@@ -1089,18 +1103,100 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             return List.of();
         }
         String tableList = description.substring(forIdx + 5, intoIdx);
-        List<String> tables = new ArrayList<>();
-        for (String token : tableList.split(",")) {
+        List<List<String>> tables = new ArrayList<>();
+        for (String token : splitOutsideQuotes(tableList, ',')) {
             String name = token.trim();
             if (name.regionMatches(true, 0, "TABLE ", 0, 6)) {
                 name = name.substring(6).trim();
             }
-            name = name.replace("\"", "");
             if (!name.isEmpty()) {
-                tables.add(name);
+                tables.add(parseQualifiedIdentifier(name));
             }
         }
         return tables;
+    }
+
+    private static List<String> splitOutsideQuotes(String value, char delimiter) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder token = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current == '"') {
+                token.append(current);
+                if (quoted && i + 1 < value.length() && value.charAt(i + 1) == '"') {
+                    token.append(value.charAt(++i));
+                }
+                else {
+                    quoted = !quoted;
+                }
+            }
+            else if (current == delimiter && !quoted) {
+                tokens.add(token.toString());
+                token.setLength(0);
+            }
+            else {
+                token.append(current);
+            }
+        }
+        tokens.add(token.toString());
+        return tokens;
+    }
+
+    private static List<String> parseQualifiedIdentifier(String identifier) {
+        List<String> components = new ArrayList<>();
+        for (String token : splitOutsideQuotes(identifier, '.')) {
+            String component = token.trim();
+            if (component.length() >= 2 && component.charAt(0) == '"'
+                    && component.charAt(component.length() - 1) == '"') {
+                component = component.substring(1, component.length() - 1).replace("\"\"", "\"");
+            }
+            components.add(component);
+        }
+        return components;
+    }
+
+    static boolean descriptionCapturesTable(String description, TableId table) {
+        List<String> expected = tableIdComponents(table);
+        return parseChangefeedTableComponents(description).stream()
+                .anyMatch(captured -> qualifiedSuffixMatches(captured, expected));
+    }
+
+    private static List<String> findExtraCapturedTablesForTableIds(String description, Collection<TableId> includedTables) {
+        List<List<String>> included = includedTables.stream()
+                .map(CockroachDBStreamingChangeEventSource::tableIdComponents)
+                .collect(Collectors.toList());
+        List<String> extras = new ArrayList<>();
+        for (List<String> captured : parseChangefeedTableComponents(description)) {
+            if (included.stream().noneMatch(candidate -> qualifiedSuffixMatches(captured, candidate))) {
+                extras.add(String.join(".", captured));
+            }
+        }
+        return extras;
+    }
+
+    private static List<String> tableIdComponents(TableId tableId) {
+        List<String> components = new ArrayList<>(3);
+        if (tableId.catalog() != null && !tableId.catalog().isEmpty()) {
+            components.add(tableId.catalog());
+        }
+        if (tableId.schema() != null && !tableId.schema().isEmpty()) {
+            components.add(tableId.schema());
+        }
+        if (tableId.table() != null && !tableId.table().isEmpty()) {
+            components.add(tableId.table());
+        }
+        return components;
+    }
+
+    private static boolean qualifiedSuffixMatches(List<String> first, List<String> second) {
+        int shared = Math.min(first.size(), second.size());
+        for (int offset = 1; offset <= shared; offset++) {
+            if (!first.get(first.size() - offset).equals(second.get(second.size() - offset))) {
+                return false;
+            }
+        }
+        return shared > 0;
     }
 
     /**
@@ -1126,13 +1222,6 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             }
         }
         return extras;
-    }
-
-    private static String sanitizeIdentifier(String identifier) {
-        if (identifier == null) {
-            return "";
-        }
-        return identifier.replaceAll("[^a-zA-Z0-9_.\\-]", "");
     }
 
     /**

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBMultiTableTest.java
@@ -56,7 +56,7 @@ public class CockroachDBMultiTableTest {
         String query = source.buildSinkChangefeedQuery(tables, null, false);
 
         assertThat(query).startsWith("CREATE CHANGEFEED FOR TABLE ");
-        assertThat(query).contains("testdb.public.orders");
+        assertThat(query).contains("\"testdb\".\"public\".\"orders\"");
         assertThat(query).contains("INTO 'kafka://kafka:9092?topic_prefix=cockroachdb.'");
         assertThat(query).contains("full_table_name");
         assertThat(query).contains("envelope = 'enriched'");
@@ -79,9 +79,9 @@ public class CockroachDBMultiTableTest {
         String query = source.buildSinkChangefeedQuery(tables, null, false);
 
         assertThat(query).startsWith("CREATE CHANGEFEED FOR TABLE ");
-        assertThat(query).contains("testdb.public.orders");
-        assertThat(query).contains("testdb.public.customers");
-        assertThat(query).contains("testdb.public.products");
+        assertThat(query).contains("\"testdb\".\"public\".\"orders\"");
+        assertThat(query).contains("\"testdb\".\"public\".\"customers\"");
+        assertThat(query).contains("\"testdb\".\"public\".\"products\"");
         // All three tables should be in a single FOR clause separated by commas
         String tablesPart = query.substring(
                 query.indexOf("FOR TABLE ") + "FOR TABLE ".length(),

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
@@ -72,8 +72,17 @@ public class CockroachDBSinklessTest {
                 List.of(new TableId("testdb", "public", "orders"),
                         new TableId("testdb", "inventory", "warehouse_items")),
                 null, false);
-        assertThat(query).contains("public.orders");
-        assertThat(query).contains("inventory.warehouse_items");
+        assertThat(query).contains("\"public\".\"orders\"");
+        assertThat(query).contains("\"inventory\".\"warehouse_items\"");
+    }
+
+    @Test
+    public void shouldQuoteIdentifiersThatRequireQuoting() {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig().build());
+        String query = source.buildSinklessChangefeedQuery(
+                List.of(new TableId("test.db", "stock-trading", "ord\"er")), null, false);
+
+        assertThat(query).contains("FOR TABLE \"test.db\".\"stock-trading\".\"ord\"\"er\" WITH");
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
@@ -248,6 +248,37 @@ public class CockroachDBStreamingChangeEventSourceTest {
     }
 
     @Test
+    void quotesStructuredIdentifierComponentsAndEscapesEmbeddedQuotes() {
+        TableId table = new TableId("test.db", "stock-trading", "ord\"er");
+
+        assertThat(CockroachDBStreamingChangeEventSource.quoteTableId(table))
+                .isEqualTo("\"test.db\".\"stock-trading\".\"ord\"\"er\"");
+
+        String query = source(baseConfig().build()).buildSinkChangefeedQuery(List.of(table), null, false);
+        assertThat(query).contains("FOR TABLE \"test.db\".\"stock-trading\".\"ord\"\"er\" INTO");
+    }
+
+    @Test
+    void parsesQuotedChangefeedDescriptionWithoutLosingIdentifierCharacters() {
+        String description = "CREATE CHANGEFEED FOR TABLE \"test.db\".\"stock-trading\".\"ord\"\"er\", "
+                + "TABLE \"test.db\".\"audit,log\".\"events\" INTO 'kafka://k' WITH OPTIONS (envelope = 'enriched')";
+
+        assertThat(CockroachDBStreamingChangeEventSource.parseChangefeedTables(description))
+                .containsExactly("test.db.stock-trading.ord\"er", "test.db.audit,log.events");
+    }
+
+    @Test
+    void matchesQuotedChangefeedDescriptionToStructuredTableId() {
+        String description = "CREATE CHANGEFEED FOR TABLE \"test.db\".\"stock-trading\".\"ord\"\"er\" "
+                + "INTO 'kafka://k?topic_prefix=crdb.' WITH OPTIONS (envelope = 'enriched')";
+
+        assertThat(CockroachDBStreamingChangeEventSource.descriptionCapturesTable(
+                description, new TableId("test.db", "stock-trading", "ord\"er"))).isTrue();
+        assertThat(CockroachDBStreamingChangeEventSource.descriptionCapturesTable(
+                description, new TableId("test.db", "stock-trading", "other"))).isFalse();
+    }
+
+    @Test
     public void shouldFindTablesTheJobCapturesBeyondTheIncludeList() {
         Set<String> included = Set.of("fdasbookdbo.account", "fdasbookdbo.journal");
         assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
@@ -8,7 +8,6 @@ package io.debezium.connector.cockroachdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -279,8 +278,21 @@ public class CockroachDBStreamingChangeEventSourceTest {
     }
 
     @Test
+    void matchesLiveSelectivelyQuotedDescriptionWithoutDatabaseComponent() {
+        String description = "CREATE CHANGEFEED FOR TABLE \"stock-trading\".order INTO 'null:' "
+                + "WITH OPTIONS (envelope = 'enriched')";
+
+        assertThat(CockroachDBStreamingChangeEventSource.parseChangefeedTables(description))
+                .containsExactly("stock-trading.order");
+        assertThat(CockroachDBStreamingChangeEventSource.descriptionCapturesTable(
+                description, new TableId("testdb", "stock-trading", "order"))).isTrue();
+    }
+
+    @Test
     public void shouldFindTablesTheJobCapturesBeyondTheIncludeList() {
-        Set<String> included = Set.of("fdasbookdbo.account", "fdasbookdbo.journal");
+        List<TableId> included = List.of(
+                new TableId("testdb", "fdasbookdbo", "account"),
+                new TableId("testdb", "fdasbookdbo", "journal"));
         assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
                 "CREATE CHANGEFEED FOR TABLE fdasbookdbo.account, TABLE fdasbookdbo.journal, "
                         + "TABLE fdasbookdbo.tax_cost_basis INTO 'kafka://k' WITH OPTIONS (envelope = 'enriched')",
@@ -290,7 +302,9 @@ public class CockroachDBStreamingChangeEventSourceTest {
 
     @Test
     public void shouldFindNoExtrasWhenTheJobMatchesTheIncludeList() {
-        Set<String> included = Set.of("fdasbookdbo.account", "fdasbookdbo.journal");
+        List<TableId> included = List.of(
+                new TableId("testdb", "fdasbookdbo", "account"),
+                new TableId("testdb", "fdasbookdbo", "journal"));
         assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
                 "CREATE CHANGEFEED FOR TABLE fdasbookdbo.account, TABLE fdasbookdbo.journal INTO 'kafka://k' "
                         + "WITH OPTIONS (envelope = 'enriched')",
@@ -302,7 +316,7 @@ public class CockroachDBStreamingChangeEventSourceTest {
     public void shouldMatchIncludedTablesByQualifiedSuffix() {
         // The job description can carry database-qualified names while the include list uses
         // schema.table form; qualification differences are not extras.
-        Set<String> included = Set.of("fdasbookdbo.account");
+        List<TableId> included = List.of(new TableId(null, "fdasbookdbo", "account"));
         assertThat(CockroachDBStreamingChangeEventSource.findExtraCapturedTables(
                 "CREATE CHANGEFEED FOR TABLE prf1fdasbook.fdasbookdbo.account INTO 'kafka://k' "
                         + "WITH OPTIONS (envelope = 'enriched')",

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -49,6 +49,8 @@ import ch.qos.logback.core.read.ListAppender;
  * <li>{@link #shouldCreateChangefeedWithKafkaSinkConfig} (debezium/dbz#2278): the
  * {@code cockroachdb.changefeed.kafka.sink.config} JSON must reach CockroachDB as the
  * {@code kafka_sink_config} changefeed option.</li>
+ * <li>DBZ-2390: generated changefeed SQL must quote a hyphenated schema and a reserved-word
+ * table in both Kafka and sinkless delivery modes.</li>
  * </ul>
  *
  * @author Virag Tripathi
@@ -252,6 +254,48 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
             assertThat(found)
                     .as("The running changefeed must carry the kafka_sink_config option")
                     .isTrue();
+        }
+    }
+
+    @Test
+    public void shouldStreamQuotedIdentifiersInKafkaMode() throws Exception {
+        connection = openDatabase("quoted_kafka_testdb");
+        createQuotedIdentifierTable(connection);
+
+        Map<String, String> config = baseConnectorConfig(
+                "quoted-kafka-test", "quoted_kafka_testdb", "stock-trading\\.order");
+        startTask(config);
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).as("Kafka mode should stream the table whose identifiers require quoting").isNotEmpty();
+        assertThat(((Struct) records.get(0).value()).getStruct("after").getInt64("id")).isEqualTo(1L);
+    }
+
+    @Test
+    public void shouldStreamQuotedIdentifiersInSinklessMode() throws Exception {
+        connection = openDatabase("quoted_sinkless_testdb");
+        createQuotedIdentifierTable(connection);
+
+        Map<String, String> config = baseConnectorConfig(
+                "quoted-sinkless-test", "quoted_sinkless_testdb", "stock-trading\\.order");
+        config.put("cockroachdb.changefeed.sink.type", "sinkless");
+        config.remove("cockroachdb.changefeed.sink.uri");
+        config.remove("cockroachdb.changefeed.kafka.bootstrap.servers");
+        config.remove("cockroachdb.changefeed.kafka.auto.offset.reset");
+        config.remove("cockroachdb.changefeed.kafka.poll.timeout.ms");
+        startTask(config);
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).as("Sinkless mode should stream the table whose identifiers require quoting").isNotEmpty();
+        assertThat(((Struct) records.get(0).value()).getStruct("after").getInt64("id")).isEqualTo(1L);
+    }
+
+    private static void createQuotedIdentifierTable(Connection connection) throws Exception {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE SCHEMA IF NOT EXISTS \"stock-trading\"");
+            stmt.execute("CREATE TABLE IF NOT EXISTS \"stock-trading\".\"order\" "
+                    + "(id INT8 PRIMARY KEY, qty INT8 NOT NULL)");
+            stmt.execute("UPSERT INTO \"stock-trading\".\"order\" VALUES (1, 10)");
         }
     }
 


### PR DESCRIPTION
## Summary

- quote every catalog, schema, and table component in generated changefeed SQL
- escape embedded double quotes without conflating dots or commas inside identifiers
- parse `SHOW CHANGEFEED JOBS` descriptions as structured qualified identifiers when reusing jobs
- cover reserved-word and hyphenated identifiers in Kafka and sinkless integration tests

Fixes debezium/dbz#2390.

## Testing

- `./mvnw clean install -Passembly -Dcockroachdb.version=v26.2.5` with JDK 21
- 260 unit tests passed after pinning the live v25.4.13 description format
- 53 integration tests total: 43 passed, 10 environment-specific tests skipped
- formatter, import sorting, checkstyle, packaging, and assembly passed
