### PR TITLE
debezium/dbz#2391 Recover when a stored cursor is stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ intermediate Kafka. See the
 [connector documentation](https://debezium.io/documentation/reference/stable/connectors/cockroachdb.html)
 for the trade-offs.
 
+### Snapshot recovery
+
+With `snapshot.mode=when_needed`, the connector normally resumes from its stored cursor. If
+CockroachDB specifically rejects that historical cursor because the required history is no longer
+available, the connector retries once without the cursor and performs a new initial scan. That scan
+re-reads rows that still exist and can therefore emit duplicates. It cannot reconstruct rows that
+were deleted while the connector was offline, so those delete events are permanently lost.
+
 ## Building
 
 Requirements: JDK 17+, Docker (for integration tests).

--- a/README.md
+++ b/README.md
@@ -65,14 +65,6 @@ intermediate Kafka. See the
 [connector documentation](https://debezium.io/documentation/reference/stable/connectors/cockroachdb.html)
 for the trade-offs.
 
-### Snapshot recovery
-
-With `snapshot.mode=when_needed`, the connector normally resumes from its stored cursor. If
-CockroachDB specifically rejects that historical cursor because the required history is no longer
-available, the connector retries once without the cursor and performs a new initial scan. That scan
-re-reads rows that still exist and can therefore emit duplicates. It cannot reconstruct rows that
-were deleted while the connector was offline, so those delete events are permanently lost.
-
 ## Building
 
 Requirements: JDK 17+, Docker (for integration tests).

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -142,7 +142,7 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     + "'initial' (default): On first start (no prior offset), the changefeed is created with initial_scan='yes'. On restart with an existing offset, it resumes streaming with cursor=<offset>.; "
                     + "'initial_only': The changefeed is created with initial_scan='only'. All existing rows are backfilled, then the connector stops.; "
                     + "'no_data'/'never': The changefeed is created with initial_scan='no'. Only ongoing changes are streamed.; "
-                    + "'when_needed': Like 'initial', but also re-snapshots if the stored offset is no longer valid.; "
+                    + "'when_needed': Like 'initial'. If CockroachDB rejects a stored cursor because its history is no longer available, the connector retries once with an initial scan. Existing rows are re-read, but deletes from the unavailable interval cannot be recovered.; "
                     + "'configuration_based': Delegates to snapshot.mode.configuration.based.* properties.; "
                     + "'custom': Loads a custom snapshotter class.");
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -208,22 +209,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             // this is a no-op; the changefeed is created and streamed during consumption.
             createChangefeeds(connection, tables, offsetContext, hasPriorOffset);
 
-            // Drive the snapshot lifecycle for the changefeed initial scan so snapshot_completed,
-            // source.snapshot, and the JMX snapshot metrics reflect reality, matching the convention
-            // the PostgreSQL and other connectors follow. Completion is signalled on the first
-            // resolved timestamp (see processChangefeedEvent).
-            if (initialScanInProgress) {
-                offsetContext.markSnapshotRecord(SnapshotRecord.TRUE);
-                if (snapshotProgressListener != null) {
-                    snapshotProgressListener.snapshotStarted(partition);
-                }
-                LOGGER.info("Initial scan started for {} table(s)", tables.size());
-            }
-            else {
-                // No initial scan (snapshot.mode no_data/never, or restart with a prior cursor):
-                // there is nothing to backfill, so mark the snapshot already completed.
-                offsetContext.markSnapshotRecord(SnapshotRecord.FALSE);
-                offsetContext.preSnapshotCompletion();
+            // A sinkless query can discover that a saved cursor is stale only when executeQuery is
+            // called. Its snapshot lifecycle is therefore initialized in consumeSinkless, after a
+            // possible when_needed fallback has selected the actual initial_scan mode.
+            if (!config.isSinklessChangefeed()) {
+                initializeSnapshotLifecycle(tables, offsetContext);
             }
 
             // Consume events: from the intermediate Kafka topics (kafka mode) or directly from a
@@ -299,6 +289,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     tables.size(), groups.size(), maxPerChangefeed);
         }
 
+        boolean recoveredFromInvalidCursor = false;
         for (List<TableId> group : groups) {
             boolean alreadyRunning = false;
             for (TableId table : group) {
@@ -312,21 +303,65 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 continue;
             }
 
-            String changefeedQuery = buildSinkChangefeedQuery(group, offsetContext.getCursor(), hasPriorOffset);
             LOGGER.info("Creating changefeed for {} table(s)", group.size());
-            LOGGER.debug("Changefeed query: {}", changefeedQuery);
 
             try (Statement stmt = connection.connection().createStatement()) {
-                stmt.execute(changefeedQuery);
+                recoveredFromInvalidCursor |= executeSinkChangefeed(
+                        stmt, group, offsetContext.getCursor(), hasPriorOffset);
                 LOGGER.info("Created changefeed for tables: {}", group);
             }
         }
 
         String initialScan = config.getInitialScanForSnapshotMode(hasPriorOffset);
-        initialScanInProgress = "yes".equals(initialScan);
+        initialScanInProgress = recoveredFromInvalidCursor || "yes".equals(initialScan);
         if (initialScanInProgress) {
             LOGGER.info("Initial scan in progress (snapshot.mode={})",
                     config.getSnapshotMode().getValue());
+        }
+    }
+
+    /**
+     * Executes a sink changefeed creation and, for {@code snapshot.mode=when_needed} only, retries
+     * once with a new initial scan when CockroachDB specifically rejects the stored cursor.
+     *
+     * @return {@code true} when the invalid-cursor recovery path was used
+     */
+    boolean executeSinkChangefeed(Statement stmt, List<TableId> tables, String cursor, boolean hasPriorOffset)
+            throws SQLException {
+        String query = buildSinkChangefeedQuery(tables, cursor, hasPriorOffset);
+        LOGGER.debug("Changefeed query: {}", query);
+        try {
+            stmt.execute(query);
+            return false;
+        }
+        catch (SQLException e) {
+            if (!shouldRecoverFromInvalidCursor(e, hasPriorOffset)) {
+                throw e;
+            }
+            logInvalidCursorRecovery(e);
+            String recoveryQuery = buildSinkChangefeedQuery(tables, null, false);
+            LOGGER.debug("Invalid-cursor recovery changefeed query: {}", recoveryQuery);
+            stmt.execute(recoveryQuery);
+            return true;
+        }
+    }
+
+    private void initializeSnapshotLifecycle(List<TableId> tables, CockroachDBOffsetContext offsetContext) {
+        // Drive the snapshot lifecycle for the changefeed initial scan so snapshot_completed,
+        // source.snapshot, and the JMX snapshot metrics reflect reality. Completion is signalled on
+        // the first resolved timestamp (see processChangefeedEvent).
+        if (initialScanInProgress) {
+            offsetContext.markSnapshotRecord(SnapshotRecord.TRUE);
+            if (snapshotProgressListener != null) {
+                snapshotProgressListener.snapshotStarted(currentPartition);
+            }
+            LOGGER.info("Initial scan started for {} table(s)", tables.size());
+        }
+        else {
+            // No initial scan (snapshot.mode no_data/never, or a valid prior cursor): there is
+            // nothing to backfill, so mark the snapshot already completed.
+            offsetContext.markSnapshotRecord(SnapshotRecord.FALSE);
+            offsetContext.preSnapshotCompletion();
         }
     }
 
@@ -652,7 +687,9 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 // CockroachDB emits it. This is independent of cockroachdb.changefeed.batch.size,
                 // which governs the kafka-mode consumer poll, not the SQL cursor.
                 stmt.setFetchSize(1);
-                try (ResultSet rs = stmt.executeQuery(changefeedQuery)) {
+                try (ResultSet rs = executeSinklessChangefeed(
+                        stmt, jdbc, tables, offsetContext.getCursor(), hasPriorOffset)) {
+                    initializeSnapshotLifecycle(tables, offsetContext);
                     while (context.isRunning() && running.get() && rs.next()) {
                         String valueJson = readChangefeedValue(rs);
                         if (valueJson == null || valueJson.trim().isEmpty()) {
@@ -687,6 +724,71 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             LOGGER.error("Error in sinkless changefeed consumption: {}", e.getMessage(), e);
             throw new RuntimeException("Failed to stream sinkless changefeed from CockroachDB: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Executes the sinkless streaming query and retries it once from a fresh initial scan when a
+     * stored cursor is rejected under {@code snapshot.mode=when_needed}. The failed statement
+     * aborts pgjdbc's explicit transaction, so it must be rolled back before the retry.
+     */
+    ResultSet executeSinklessChangefeed(Statement stmt, Connection connection, List<TableId> tables,
+                                        String cursor, boolean hasPriorOffset)
+            throws SQLException {
+        String query = buildSinklessChangefeedQuery(tables, cursor, hasPriorOffset);
+        try {
+            return stmt.executeQuery(query);
+        }
+        catch (SQLException e) {
+            if (!shouldRecoverFromInvalidCursor(e, hasPriorOffset)) {
+                throw e;
+            }
+            logInvalidCursorRecovery(e);
+            connection.rollback();
+            initialScanInProgress = true;
+            String recoveryQuery = buildSinklessChangefeedQuery(tables, null, false);
+            LOGGER.debug("Invalid-cursor recovery sinkless query: {}", recoveryQuery);
+            return stmt.executeQuery(recoveryQuery);
+        }
+    }
+
+    private boolean shouldRecoverFromInvalidCursor(SQLException exception, boolean hasPriorOffset) {
+        return hasPriorOffset
+                && config.getSnapshotMode() == CockroachDBConnectorConfig.SnapshotMode.WHEN_NEEDED
+                && isInvalidCursorRejection(exception);
+    }
+
+    private void logInvalidCursorRecovery(SQLException exception) {
+        LOGGER.warn("CockroachDB rejected the stored changefeed cursor while snapshot.mode=when_needed is configured. "
+                + "Retrying once without the cursor and with an initial scan. Existing rows will be re-read and "
+                + "duplicate events can be emitted. Deletes that occurred while the connector was offline cannot "
+                + "be recovered by this snapshot and will be lost. CockroachDB error: {}", exception.getMessage());
+    }
+
+    /**
+     * Recognizes only CockroachDB's specific historical-cursor failures. General undefined-table,
+     * connectivity, authorization, and syntax failures deliberately do not match.
+     */
+    static boolean isInvalidCursorRejection(SQLException exception) {
+        for (SQLException current = exception; current != null; current = current.getNextException()) {
+            if (isInvalidCursorMessage(current.getMessage())) {
+                return true;
+            }
+        }
+        for (Throwable current = exception.getCause(); current != null; current = current.getCause()) {
+            if (isInvalidCursorMessage(current.getMessage())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isInvalidCursorMessage(String message) {
+        if (message == null) {
+            return false;
+        }
+        String normalized = message.toLowerCase(Locale.ROOT);
+        return normalized.contains("do the targets exist at the specified cursor time")
+                || normalized.contains("must be after replica gc threshold");
     }
 
     /**

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBSinklessTest.java
@@ -6,7 +6,16 @@
 package io.debezium.connector.cockroachdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +83,31 @@ public class CockroachDBSinklessTest {
                 null, false);
         assertThat(query).contains("public.orders");
         assertThat(query).contains("inventory.warehouse_items");
+    }
+
+    @Test
+    public void shouldRollbackAndRetrySinklessQueryForWhenNeeded() throws Exception {
+        CockroachDBStreamingChangeEventSource source = createSource(sinklessConfig()
+                .with("snapshot.mode", "when_needed")
+                .build());
+        Statement statement = mock(Statement.class);
+        Connection connection = mock(Connection.class);
+        ResultSet recoveredResult = mock(ResultSet.class);
+        SQLException staleCursor = new SQLException(
+                "batch timestamp 1 must be after replica GC threshold 2", "XXUUU");
+        when(statement.executeQuery(anyString())).thenThrow(staleCursor).thenReturn(recoveredResult);
+
+        ResultSet result = source.executeSinklessChangefeed(
+                statement, connection, List.of(new TableId("testdb", "public", "orders")), "1.0000000000", true);
+
+        assertThat(result).isSameAs(recoveredResult);
+        verify(connection).rollback();
+        org.mockito.ArgumentCaptor<String> queries = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(statement, times(2)).executeQuery(queries.capture());
+        assertThat(queries.getAllValues().get(0)).contains("cursor = '1.0000000000'");
+        assertThat(queries.getAllValues().get(1))
+                .contains("initial_scan = 'yes'")
+                .doesNotContain("cursor =");
     }
 
     @Test

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSourceTest.java
@@ -6,11 +6,20 @@
 package io.debezium.connector.cockroachdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -181,6 +190,77 @@ public class CockroachDBStreamingChangeEventSourceTest {
                 .with("topic.prefix", "crdb")
                 .with("cockroachdb.changefeed.sink.type", "kafka")
                 .with("cockroachdb.changefeed.sink.uri", "kafka://kafka:9092");
+    }
+
+    @Test
+    void recognizesOnlyCockroachDbHistoricalCursorFailures() {
+        SQLException missingAtCursor = new SQLException(
+                "failed to resolve targets in the CHANGEFEED stmt: table does not exist "
+                        + "HINT: do the targets exist at the specified cursor time 1?",
+                "42P01");
+        SQLException belowGcThreshold = new SQLException(
+                "batch timestamp 1 must be after replica GC threshold 2", "XXUUU");
+
+        assertThat(CockroachDBStreamingChangeEventSource.isInvalidCursorRejection(missingAtCursor)).isTrue();
+        assertThat(CockroachDBStreamingChangeEventSource.isInvalidCursorRejection(belowGcThreshold)).isTrue();
+        assertThat(CockroachDBStreamingChangeEventSource.isInvalidCursorRejection(
+                new SQLException("table orders does not exist", "42P01"))).isFalse();
+        assertThat(CockroachDBStreamingChangeEventSource.isInvalidCursorRejection(
+                new SQLException("connection refused", "08001"))).isFalse();
+    }
+
+    @Test
+    void retriesSinkChangefeedOnceWithoutCursorForWhenNeeded() throws Exception {
+        CockroachDBStreamingChangeEventSource source = source(baseConfig()
+                .with("snapshot.mode", "when_needed")
+                .build());
+        Statement statement = mock(Statement.class);
+        SQLException staleCursor = new SQLException(
+                "HINT: do the targets exist at the specified cursor time 1?", "42P01");
+        doThrow(staleCursor).doReturn(false).when(statement).execute(anyString());
+
+        boolean recovered = source.executeSinkChangefeed(
+                statement, List.of(new TableId("testdb", "public", "orders")), "1.0000000000", true);
+
+        assertThat(recovered).isTrue();
+        ArgumentCaptor<String> queries = ArgumentCaptor.forClass(String.class);
+        verify(statement, times(2)).execute(queries.capture());
+        assertThat(queries.getAllValues().get(0))
+                .contains("cursor = '1.0000000000'", "initial_scan = 'no'");
+        assertThat(queries.getAllValues().get(1))
+                .contains("initial_scan = 'yes'")
+                .doesNotContain("cursor =");
+    }
+
+    @Test
+    void doesNotRetryInvalidCursorOutsideWhenNeededMode() throws Exception {
+        CockroachDBStreamingChangeEventSource source = source(baseConfig()
+                .with("snapshot.mode", "initial")
+                .build());
+        Statement statement = mock(Statement.class);
+        SQLException staleCursor = new SQLException(
+                "HINT: do the targets exist at the specified cursor time 1?", "42P01");
+        doThrow(staleCursor).when(statement).execute(anyString());
+
+        assertThatThrownBy(() -> source.executeSinkChangefeed(
+                statement, List.of(new TableId("testdb", "public", "orders")), "1.0000000000", true))
+                .isSameAs(staleCursor);
+        verify(statement, times(1)).execute(anyString());
+    }
+
+    @Test
+    void doesNotRetryUnrelatedSqlFailuresInWhenNeededMode() throws Exception {
+        CockroachDBStreamingChangeEventSource source = source(baseConfig()
+                .with("snapshot.mode", "when_needed")
+                .build());
+        Statement statement = mock(Statement.class);
+        SQLException permissionDenied = new SQLException("user does not have CHANGEFEED privilege", "42501");
+        doThrow(permissionDenied).when(statement).execute(anyString());
+
+        assertThatThrownBy(() -> source.executeSinkChangefeed(
+                statement, List.of(new TableId("testdb", "public", "orders")), "1.0000000000", true))
+                .isSameAs(permissionDenied);
+        verify(statement, times(1)).execute(anyString());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- recognize only CockroachDB's specific stale historical-cursor failures
- retry changefeed creation once without the rejected cursor when `snapshot.mode=when_needed`
- perform a new initial scan and update snapshot lifecycle state for Kafka and sinkless delivery
- roll back the aborted sinkless SQL transaction before retrying
- warn explicitly about possible duplicate records and unrecoverable deletes

Fixes debezium/dbz#2391.

## Documentation

- debezium/debezium#7811 documents duplicate-event and unrecoverable-delete caveats in the authoritative connector reference

## Testing

- `./mvnw clean install -Passembly -Dcockroachdb.version=v26.2.5` with JDK 21
- 260 unit tests passed
- 51 integration tests total: 41 passed, 10 environment-specific tests skipped
- formatter, import sorting, checkstyle, packaging, and assembly passed
