### PR TITLE
debezium/dbz#2392 Warn about uncaptured snapshot tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,6 @@ Runnable end-to-end examples (CockroachDB to CockroachDB, Oracle, Iceberg, sinkl
 embedded engine, and workload-based verification) live in the
 [examples repository](https://github.com/viragtripathi/debezium-cockroachdb-examples).
 
-## Table discovery
-
-The connector resolves `table.include.list` and `table.exclude.list` patterns when the task starts
-and freezes the discovered tables into the running CockroachDB changefeed. A table created later is
-not captured automatically, even when its name matches an include-list regular expression. Restart
-the connector to rediscover and add it. An `execute-snapshot` signal that requests a table outside
-the running capture set logs a warning; restart the connector before snapshotting that table so its
-subsequent changes are also streamed. This behavior is the same for `kafka` and `sinkless` delivery.
-
 ## Quick start
 
 Install the plugin from Maven Central

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ Runnable end-to-end examples (CockroachDB to CockroachDB, Oracle, Iceberg, sinkl
 embedded engine, and workload-based verification) live in the
 [examples repository](https://github.com/viragtripathi/debezium-cockroachdb-examples).
 
+## Table discovery
+
+The connector resolves `table.include.list` and `table.exclude.list` patterns when the task starts
+and freezes the discovered tables into the running CockroachDB changefeed. A table created later is
+not captured automatically, even when its name matches an include-list regular expression. Restart
+the connector to rediscover and add it. An `execute-snapshot` signal that requests a table outside
+the running capture set logs a warning; restart the connector before snapshotting that table so its
+subsequent changes are also streamed. This behavior is the same for `kafka` and `sinkless` delivery.
+
 ## Quick start
 
 Install the plugin from Maven Central

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeEventSourceFactory.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBChangeEventSourceFactory.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.cockroachdb;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,7 @@ public class CockroachDBChangeEventSourceFactory implements ChangeEventSourceFac
     private final EventDispatcher<CockroachDBPartition, TableId> dispatcher;
     private final CockroachDBSchema schema;
     private final Clock clock;
+    private final Set<TableId> capturedTables;
 
     /**
      * Captured from {@link #getSnapshotChangeEventSource} (the coordinator builds the snapshot source
@@ -54,6 +56,7 @@ public class CockroachDBChangeEventSourceFactory implements ChangeEventSourceFac
         this.dispatcher = dispatcher;
         this.schema = schema;
         this.clock = clock;
+        this.capturedTables = Set.copyOf(schema.getDiscoveredTables());
     }
 
     @Override
@@ -90,7 +93,8 @@ public class CockroachDBChangeEventSourceFactory implements ChangeEventSourceFac
                 clock,
                 snapshotProgressListener,
                 dataChangeEventListener,
-                notificationService));
+                notificationService,
+                capturedTables));
     }
 
 }

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -90,8 +91,15 @@ public class CockroachDBSignalBasedIncrementalSnapshotChangeEventSource
     static List<String> findUncapturedDataCollections(Collection<TableId> capturedTables, List<String> requestedPatterns) {
         return requestedPatterns.stream()
                 .filter(requested -> {
-                    Pattern pattern = Pattern.compile(requested);
-                    return capturedTables.stream().noneMatch(table -> matches(pattern, table));
+                    try {
+                        Pattern pattern = Pattern.compile(requested);
+                        return capturedTables.stream().noneMatch(table -> matches(pattern, table));
+                    }
+                    catch (PatternSyntaxException e) {
+                        LOGGER.warn("Incremental snapshot signal contains malformed data collection pattern '{}'; "
+                                + "treating it as uncaptured: {}", requested, e.getDescription());
+                        return true;
+                    }
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -6,6 +6,11 @@
 package io.debezium.connector.cockroachdb;
 
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +19,8 @@ import io.debezium.connector.cockroachdb.connection.CockroachDBConnection;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.signal.SignalPayload;
+import io.debezium.pipeline.signal.actions.snapshotting.SnapshotConfiguration;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
@@ -39,6 +46,7 @@ public class CockroachDBSignalBasedIncrementalSnapshotChangeEventSource
 
     private final CockroachDBConnection cockroachDBConnection;
     private final CockroachDBSchema cockroachDBSchema;
+    private final Set<TableId> capturedTables;
 
     public CockroachDBSignalBasedIncrementalSnapshotChangeEventSource(
                                                                       RelationalDatabaseConnectorConfig config,
@@ -48,7 +56,8 @@ public class CockroachDBSignalBasedIncrementalSnapshotChangeEventSource
                                                                       Clock clock,
                                                                       SnapshotProgressListener<CockroachDBPartition> progressListener,
                                                                       DataChangeEventListener<CockroachDBPartition> dataChangeEventListener,
-                                                                      NotificationService<CockroachDBPartition, ? extends OffsetContext> notificationService) {
+                                                                      NotificationService<CockroachDBPartition, ? extends OffsetContext> notificationService,
+                                                                      Collection<TableId> capturedTables) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         if (!(jdbcConnection instanceof CockroachDBConnection)) {
             throw new IllegalArgumentException("Expected CockroachDBConnection but got " + jdbcConnection.getClass().getName());
@@ -58,6 +67,43 @@ public class CockroachDBSignalBasedIncrementalSnapshotChangeEventSource
         }
         this.cockroachDBConnection = (CockroachDBConnection) jdbcConnection;
         this.cockroachDBSchema = (CockroachDBSchema) databaseSchema;
+        this.capturedTables = Set.copyOf(capturedTables);
+    }
+
+    @Override
+    public void addDataCollectionNamesToSnapshot(
+                                                 SignalPayload<CockroachDBPartition> signalPayload,
+                                                 SnapshotConfiguration snapshotConfiguration)
+            throws InterruptedException {
+        List<String> uncaptured = findUncapturedDataCollections(
+                capturedTables, snapshotConfiguration.getDataCollections());
+        if (!uncaptured.isEmpty()) {
+            LOGGER.warn("Incremental snapshot signal '{}' requests data collection pattern(s) {} that match no table "
+                    + "in the running CockroachDB changefeed capture set. table.include.list patterns are resolved "
+                    + "only when the connector starts; a table created later is not streamed even if it matches the "
+                    + "configured pattern. Restart the connector to rediscover the table and then reissue the "
+                    + "snapshot signal; without that restart, subsequent changes will not be captured.", signalPayload.id, uncaptured);
+        }
+        super.addDataCollectionNamesToSnapshot(signalPayload, snapshotConfiguration);
+    }
+
+    static List<String> findUncapturedDataCollections(Collection<TableId> capturedTables, List<String> requestedPatterns) {
+        return requestedPatterns.stream()
+                .filter(requested -> {
+                    Pattern pattern = Pattern.compile(requested);
+                    return capturedTables.stream().noneMatch(table -> matches(pattern, table));
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static boolean matches(Pattern pattern, TableId table) {
+        if (pattern.matcher(table.identifier()).matches()) {
+            return true;
+        }
+        String schemaAndTable = table.schema() == null || table.schema().isEmpty()
+                ? table.table()
+                : table.schema() + "." + table.table();
+        return pattern.matcher(schemaAndTable).matches();
     }
 
     @Override

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
@@ -8,8 +8,10 @@ package io.debezium.connector.cockroachdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -91,5 +93,28 @@ public class CockroachDBIncrementalSnapshotTest {
         Optional<Boolean> nullsSortLast = conn.nullsSortLast();
         assertThat(nullsSortLast).isPresent();
         assertThat(nullsSortLast.get()).isTrue();
+    }
+
+    @Test
+    public void shouldIdentifySnapshotRequestsOutsideFrozenChangefeedSet() {
+        Set<TableId> captured = Set.of(
+                new TableId("testdb", "public", "orders"),
+                new TableId("testdb", "inventory", "products"));
+
+        assertThat(CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.findUncapturedDataCollections(
+                captured,
+                List.of("testdb\\.public\\.orders", "inventory\\.products", "testdb\\.public\\.late_.*")))
+                .containsExactly("testdb\\.public\\.late_.*");
+    }
+
+    @Test
+    public void shouldAcceptSnapshotRegexMatchingAtLeastOneCapturedTable() {
+        Set<TableId> captured = Set.of(
+                new TableId("testdb", "public", "orders_2025"),
+                new TableId("testdb", "public", "orders_2026"));
+
+        assertThat(CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.findUncapturedDataCollections(
+                captured, List.of("testdb\\.public\\.orders_.*")))
+                .isEmpty();
     }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBIncrementalSnapshotTest.java
@@ -14,11 +14,17 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotContext;
 import io.debezium.relational.TableId;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 
 /**
  * Unit tests for CockroachDB incremental snapshot support.
@@ -116,5 +122,29 @@ public class CockroachDBIncrementalSnapshotTest {
         assertThat(CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.findUncapturedDataCollections(
                 captured, List.of("testdb\\.public\\.orders_.*")))
                 .isEmpty();
+    }
+
+    @Test
+    public void shouldTreatMalformedSnapshotRegexAsUncapturedAndWarn() {
+        Logger logger = (Logger) LoggerFactory.getLogger(CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.class);
+        ListAppender<ILoggingEvent> warnings = new ListAppender<>();
+        warnings.start();
+        logger.addAppender(warnings);
+
+        try {
+            assertThat(CockroachDBSignalBasedIncrementalSnapshotChangeEventSource.findUncapturedDataCollections(
+                    Set.of(new TableId("testdb", "public", "orders")), List.of("testdb\\.public\\.[")))
+                    .containsExactly("testdb\\.public\\.[");
+            assertThat(warnings.list)
+                    .anySatisfy(event -> {
+                        assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                        assertThat(event.getFormattedMessage())
+                                .contains("malformed data collection pattern", "testdb\\.public\\.[", "treating it as uncaptured");
+                    });
+        }
+        finally {
+            logger.detachAppender(warnings);
+            warnings.stop();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- freeze the discovered CockroachDB changefeed capture set when the task starts
- compare incremental snapshot signal patterns with that running capture set
- warn when a requested pattern matches no captured table
- treat malformed signal regular expressions as uncaptured and log a warning
- explain that the connector must be restarted and the snapshot signal reissued

Fixes debezium/dbz#2392.

## Documentation

- debezium/debezium#7812 documents startup-time table discovery for Kafka and sinkless delivery

## Testing

- `./mvnw clean install -Passembly -Dcockroachdb.version=v26.2.5` with JDK 21
- 258 unit tests passed
- 51 integration tests total: 41 passed, 10 environment-specific tests skipped
- formatter, import sorting, checkstyle, packaging, and assembly passed
