### PR TITLE
debezium/dbz#2413 Test against CockroachDB v25.4.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,11 @@
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- JSON processing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <!-- Debezium parent -->
         <version.debezium>${project.version}</version.debezium>
 
-        <cockroachdb.version>v25.4.13</cockroachdb.version>
+        <cockroachdb.version>v25.4.14</cockroachdb.version>
         <version.jmh>1.37</version.jmh>
         <version.jacoco>0.8.12</version.jacoco>
         <!-- Overridden by the JaCoCo agent at runtime; empty so plain builds are unaffected. -->


### PR DESCRIPTION
Moves the centrally pinned cockroachdb.version to v25.4.14, the latest v25.4 LTS patch. The examples repository moved to the same version.

Also declares connect-json as a test-scoped dependency: CockroachDBValueConverterProviderTest uses JsonConverter directly but relied on a transitive path that current Debezium 3.7.0-SNAPSHOT parent artifacts no longer provide (debezium/dbz#2414).

Verification: full unit suite and Testcontainers integration suite pass against v25.4.14; the crdb-to-crdb example demo including the bank workload runs green on the same version.

Closes https://github.com/debezium/dbz/issues/2413
Closes https://github.com/debezium/dbz/issues/2414