### PR TITLE
debezium/dbz#2417 Match core pull request branches by exact name in Cross Maven CI

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -46,7 +46,7 @@ jobs:
 
           while IFS=" " read -r BRANCH;
           do
-            if grep -q "$branch_name" <<< "$BRANCH"; then
+            if [ "$BRANCH" = "$branch_name" ]; then
               echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
             fi
           done < SORTED_PULLS.txt


### PR DESCRIPTION
The branch-exists check greps the open core PR branch list with a substring match, so a core branch that merely contains the connector branch name, such as a docs companion branch dbz-2391-docs next to connector branch dbz-2391, sets BRANCH_FOUND=true and the exact-ref checkout then fails. Seen on #74 and #75. Compares for exact equality instead.

Closes https://github.com/debezium/dbz/issues/2417