### PR TITLE
debezium/dbz#2432 Emit schema and table in the source info block

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContext.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBOffsetContext.java
@@ -124,6 +124,9 @@ public class CockroachDBOffsetContext extends CommonOffsetContext<SourceInfo> {
     @Override
     public void event(DataCollectionId collectionId, Instant ts) {
         setTimestamp(ts);
+        if (collectionId instanceof TableId) {
+            sourceInfo.tableEvent((TableId) collectionId);
+        }
     }
 
     @Override

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSourceInfoStructMaker.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBSourceInfoStructMaker.java
@@ -39,6 +39,8 @@ public class CockroachDBSourceInfoStructMaker extends AbstractSourceInfoStructMa
 
     // CockroachDB-specific field names
     // Note: "db" and "ts_ns" fields are already provided by the base class, so we don't duplicate them
+    private static final String FIELD_SCHEMA_NAME = "schema";
+    private static final String FIELD_TABLE_NAME = "table";
     private static final String FIELD_CLUSTER = "cluster";
     private static final String FIELD_RESOLVED_TS = "resolved_ts";
     private static final String FIELD_HLC = "ts_hlc";
@@ -53,6 +55,8 @@ public class CockroachDBSourceInfoStructMaker extends AbstractSourceInfoStructMa
         this.schema = commonSchemaBuilder()
                 .name("io.debezium.connector.cockroachdb.Source")
                 // Note: "db" and "ts_ns" fields are already included by commonSchemaBuilder()
+                .field(FIELD_SCHEMA_NAME, Schema.OPTIONAL_STRING_SCHEMA) // schema of the event's table
+                .field(FIELD_TABLE_NAME, Schema.OPTIONAL_STRING_SCHEMA) // table of the event
                 .field(FIELD_CLUSTER, Schema.OPTIONAL_STRING_SCHEMA) // CockroachDB cluster name
                 .field(FIELD_RESOLVED_TS, Schema.OPTIONAL_STRING_SCHEMA) // Resolved timestamp for consistency
                 .field(FIELD_HLC, Schema.OPTIONAL_STRING_SCHEMA) // Hybrid Logical Clock timestamp
@@ -72,6 +76,12 @@ public class CockroachDBSourceInfoStructMaker extends AbstractSourceInfoStructMa
         Objects.requireNonNull(sourceInfo, "sourceInfo must not be null");
 
         Struct result = super.commonStruct(sourceInfo);
+        if (sourceInfo.schemaName() != null) {
+            result.put(FIELD_SCHEMA_NAME, sourceInfo.schemaName());
+        }
+        if (sourceInfo.tableName() != null) {
+            result.put(FIELD_TABLE_NAME, sourceInfo.tableName());
+        }
         result.put(FIELD_CLUSTER, sourceInfo.cluster());
         result.put(FIELD_RESOLVED_TS, sourceInfo.resolvedTimestamp());
 

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -951,6 +951,11 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                 keyNode = (parsedKey != null && parsedKey.has("payload")) ? parsedKey.get("payload") : parsedKey;
             }
 
+            // Record the event's collection on the offset context so the source block carries
+            // schema and table (debezium/dbz#2432). The timestamp is passed through unchanged;
+            // it advances only on resolved timestamps, as before.
+            offsetContext.event(table, offsetContext.getTimestamp());
+
             CockroachDBChangeRecordEmitter emitter = new CockroachDBChangeRecordEmitter(
                     currentPartition, offsetContext, clock, config, tableObj, operation,
                     afterNode.isMissingNode() ? null : afterNode,

--- a/src/main/java/io/debezium/connector/cockroachdb/SourceInfo.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/SourceInfo.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.connector.common.BaseSourceInfo;
+import io.debezium.relational.TableId;
 
 /**
  * Coordinates metadata from CockroachDB changefeed events
@@ -26,11 +27,32 @@ public class SourceInfo extends BaseSourceInfo {
     private String resolvedTimestamp;
     private String hlc;
     private Long tsNanos;
+    private String schemaName;
+    private String tableName;
 
     protected SourceInfo(CockroachDBConnectorConfig connectorConfig) {
         super(connectorConfig);
         this.databaseName = connectorConfig.getDatabaseName();
         this.clusterName = connectorConfig.getLogicalName();
+    }
+
+    /**
+     * Records the collection of the event being emitted so the source block carries its
+     * schema and table, matching the PostgreSQL and SQL Server connectors.
+     */
+    public void tableEvent(TableId tableId) {
+        if (tableId != null) {
+            this.schemaName = tableId.schema();
+            this.tableName = tableId.table();
+        }
+    }
+
+    public String schemaName() {
+        return schemaName;
+    }
+
+    public String tableName() {
+        return tableName;
     }
 
     public void setSourceTime(Instant instant) {

--- a/src/test/java/io/debezium/connector/cockroachdb/SourceInfoTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/SourceInfoTest.java
@@ -181,4 +181,25 @@ public class SourceInfoTest {
         assertThat(stringRepresentation).isNotNull();
         assertThat(stringRepresentation).isNotEmpty();
     }
+
+    @Test
+    public void shouldExposeSchemaAndTableOfTheCurrentEvent() {
+        sourceInfo.tableEvent(new io.debezium.relational.TableId("testdb", "pierbookdbo", "account"));
+
+        assertThat(sourceInfo.schemaName()).isEqualTo("pierbookdbo");
+        assertThat(sourceInfo.tableName()).isEqualTo("account");
+
+        Struct struct = sourceInfo.struct();
+        assertThat(struct.getString("schema")).isEqualTo("pierbookdbo");
+        assertThat(struct.getString("table")).isEqualTo("account");
+    }
+
+    @Test
+    public void shouldOmitSchemaAndTableUntilAnEventArrives() {
+        Struct struct = sourceInfo.struct();
+        assertThat(struct.schema().field("schema")).isNotNull();
+        assertThat(struct.schema().field("table")).isNotNull();
+        assertThat(struct.getString("schema")).isNull();
+        assertThat(struct.getString("table")).isNull();
+    }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -299,6 +299,27 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
         }
     }
 
+    @Test
+    public void shouldCarrySchemaAndTableInTheSourceBlock() throws Exception {
+        connection = openDatabase("srcblock_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS accounts (id INT8 PRIMARY KEY, balance INT8 NOT NULL)");
+            stmt.execute("UPSERT INTO accounts VALUES (1, 100)");
+        }
+
+        Map<String, String> config = baseConnectorConfig(
+                "srcblock-test", "srcblock_testdb", "public\\.accounts");
+        startTask(config);
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).isNotEmpty();
+        Struct source = ((Struct) records.get(0).value()).getStruct("source");
+        assertThat(source.getString("schema"))
+                .as("source.schema enables JDBC sink routing via ${source.schema} (debezium/dbz#2432)")
+                .isEqualTo("public");
+        assertThat(source.getString("table")).isEqualTo("accounts");
+    }
+
     private boolean isDelete(SourceRecord record) {
         if (record.value() == null) {
             return false;


### PR DESCRIPTION
The source block carried db plus the CockroachDB-specific fields but not the schema and table of the event's collection, which the PostgreSQL and SQL Server connectors emit and which the connector documentation's source block example already shows. This blocked JDBC sink topic-to-table routing with collection.name.format templates such as ${source.schema}_${source.table} when fanning multiple topics into one sink connector.

Populates schema and table from the event's TableId in the offset context event() callback, which the streaming dispatch now invokes before building the change record emitter, and emits both as optional fields from the source info struct maker.

Verification: unit tests for the new accessors and struct fields, a pipeline integration scenario asserting both fields on a streamed record, the full unit and integration suites, the crdb-to-crdb example built from this branch including a sink configured with topics.regex and collection.name.format ${source.schema}_${source.table} routing two topics into per-table target tables, and the cloud connection suite against CockroachDB Cloud.

Closes https://github.com/debezium/dbz/issues/2432