### PR TITLE
debezium/dbz#2462 Fail fast when a matching changefeed job is paused

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -423,12 +423,24 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
         String sinkMarker = "topic_prefix=" + topicPrefix;
 
         try (Statement stmt = connection.connection().createStatement()) {
-            String query = "SELECT job_id, description FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running'";
+            // Paused jobs are matched too: a paused job is invisible to a running-only check,
+            // so a restart would create an identical twin that double-produces once the paused
+            // job resumes (debezium/dbz#2462). Canceled and failed jobs are correctly ignored.
+            String query = "SELECT job_id, status, description FROM [SHOW CHANGEFEED JOBS] "
+                    + "WHERE status IN ('running', 'paused', 'pause-requested')";
             try (var rs = stmt.executeQuery(query)) {
                 while (rs.next()) {
                     String jobId = rs.getString(1);
-                    String description = rs.getString(2);
+                    String status = rs.getString(2);
+                    String description = rs.getString(3);
                     if (description != null && descriptionCapturesTable(description, table) && description.contains(sinkMarker)) {
+                        if (!"running".equals(status)) {
+                            throw new IllegalStateException("Found changefeed job " + jobId + " covering table " + table
+                                    + " with topic prefix '" + topicPrefix + "' in status '" + status + "'. Starting anyway would "
+                                    + "create a duplicate changefeed that double-produces into the same intermediate topics once "
+                                    + "the paused job resumes. Resume it (RESUME JOB " + jobId + ") or cancel it (CANCEL JOB "
+                                    + jobId + ") before starting the connector.");
+                        }
                         // A changefeed with our topic prefix already covers this table. The connector
                         // can only consume the enriched envelope, so refuse to reuse one created with a
                         // different envelope rather than consuming it and failing to parse events. We

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -227,6 +227,63 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
     }
 
     @Test
+    public void shouldFailFastWhenMatchingChangefeedIsPaused() throws Exception {
+        connection = openDatabase("reuse_paused_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS paused_events (id INT8 PRIMARY KEY, name STRING NOT NULL)");
+            stmt.execute("UPSERT INTO paused_events VALUES (1, 'Alice')");
+        }
+
+        // First run creates the changefeed.
+        startTask(baseConnectorConfig("paused-test", "reuse_paused_testdb", "public.paused_events"));
+        assertThat(pollUntilRecordsOrError(30).records).as("First run should stream the seed row").isNotEmpty();
+        stopTask();
+
+        // Pause the job, as an operator doing maintenance would. The job is now invisible to a
+        // running-only reuse check; without the guard the connector creates an identical twin
+        // that double-produces once the paused job resumes (debezium/dbz#2462).
+        String jobId = null;
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT job_id FROM [SHOW CHANGEFEED JOBS] WHERE status = 'running' AND description LIKE '%paused_events%'")) {
+            if (rs.next()) {
+                jobId = rs.getString(1);
+            }
+        }
+        assertThat(jobId).as("The first run's changefeed job must exist").isNotNull();
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("PAUSE JOB " + jobId);
+        }
+        // PAUSE is asynchronous: wait for the job to leave the running state.
+        for (int i = 0; i < 30; i++) {
+            try (Statement stmt = connection.createStatement();
+                    ResultSet rs = stmt.executeQuery(
+                            "SELECT status FROM [SHOW CHANGEFEED JOBS] WHERE job_id = " + jobId)) {
+                if (rs.next() && "paused".equals(rs.getString(1))) {
+                    break;
+                }
+            }
+            Thread.sleep(1000);
+        }
+
+        // Second run must fail fast instead of creating a duplicate changefeed.
+        startTask(baseConnectorConfig("paused-test", "reuse_paused_testdb", "public.paused_events"));
+        PollOutcome outcome = pollUntilRecordsOrError(45);
+        assertThat(outcome.error)
+                .as("Startup with a matching paused changefeed should fail fast, not create a twin")
+                .isNotNull();
+        assertThat(outcome.error.getMessage() + " " + rootCauseMessage(outcome.error))
+                .contains("paused");
+
+        try (Statement stmt = connection.createStatement();
+                ResultSet rs = stmt.executeQuery(
+                        "SELECT count(*) FROM [SHOW CHANGEFEED JOBS] WHERE status IN ('running', 'paused') AND description LIKE '%paused_events%'")) {
+            rs.next();
+            assertThat(rs.getInt(1)).as("No duplicate changefeed job may be created").isEqualTo(1);
+        }
+    }
+
+    @Test
     public void shouldCreateChangefeedWithKafkaSinkConfig() throws Exception {
         connection = openDatabase("sinkcfg_testdb");
         try (Statement stmt = connection.createStatement()) {


### PR DESCRIPTION
The reuse check queried SHOW CHANGEFEED JOBS with status = 'running' only, so a changefeed paused during a connector restart was invisible: the connector created an identical twin, and resuming the paused job left two jobs producing every change twice into the same intermediate topics. Observed in a production deployment after an include-list change with a restart.

Extends the reuse query to paused and pause-requested jobs and fails fast with the job id and RESUME JOB / CANCEL JOB remediation when a matching non-running job is found, mirroring how an envelope or diff mismatch on a matching job fails fast instead of creating a duplicate. Canceled and failed jobs are still ignored.

Verification: a new integration scenario pauses the job between runs and asserts the second start fails with the paused-job message and that no duplicate job exists; the full unit and integration suites pass.

Closes https://github.com/debezium/dbz/issues/2462