### PR TITLE
debezium/dbz#2463 Point the build badge at the maven.yml workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Maven Central](https://img.shields.io/maven-central/v/io.debezium/debezium-connector-cockroachdb.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:io.debezium%20AND%20a:debezium-connector-cockroachdb)
-[![Build Status](https://github.com/debezium/debezium-connector-cockroachdb/workflows/CI/badge.svg)](https://github.com/debezium/debezium-connector-cockroachdb/actions)
+[![Build Status](https://github.com/debezium/debezium-connector-cockroachdb/actions/workflows/maven.yml/badge.svg)](https://github.com/debezium/debezium-connector-cockroachdb/actions/workflows/maven.yml)
 [![Community](https://img.shields.io/badge/Community-Zulip-blue.svg)](https://debezium.zulipchat.com/#narrow/channel/510960-community-cockroachdb)
 
 Copyright Debezium Authors.


### PR DESCRIPTION
The badge used the name-based URL for a workflow named CI, which does not exist (the build workflow is named Maven CI), so it rendered as no status. Uses the file-based badge URL, which is stable across workflow display-name changes, and links to the workflow's runs page.

Closes https://github.com/debezium/dbz/issues/2463