### PR TITLE
debezium/dbz#2472 Optionally commit consumer positions to the Kafka group

### DIFF
--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfig.java
@@ -367,6 +367,20 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
             .withDescription("What to do when there is no initial offset in Kafka. "
                     + "Options: 'earliest' (start from beginning), 'latest' (start from end).");
 
+    public static final Field CHANGEFEED_KAFKA_CONSUMER_OFFSET_COMMIT_ENABLED = Field.create("cockroachdb.changefeed.kafka.consumer.offset.commit.enabled")
+            .withDisplayName("Kafka consumer offset commit enabled")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_ADVANCED))
+            .withDefault(false)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Whether the connector also commits its consumed positions to the Kafka consumer "
+                    + "group after each processed batch, so that external lag tooling such as "
+                    + "kafka-consumer-groups reflects the connector's progress on the intermediate topics. "
+                    + "Disabled by default. The connector always resumes from the positions stored in the "
+                    + "Debezium offsets, never from the group, so this option has no effect on delivery "
+                    + "semantics.");
+
     public static final Field CHANGEFEED_SINK_OPTIONS = Field.create("cockroachdb.changefeed.sink.options")
             .withDisplayName("Changefeed sink options")
             .withType(Type.STRING)
@@ -546,6 +560,7 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
                     CHANGEFEED_KAFKA_CONSUMER_GROUP_PREFIX,
                     CHANGEFEED_KAFKA_POLL_TIMEOUT_MS,
                     CHANGEFEED_KAFKA_AUTO_OFFSET_RESET,
+                    CHANGEFEED_KAFKA_CONSUMER_OFFSET_COMMIT_ENABLED,
                     CHANGEFEED_KAFKA_BOOTSTRAP_SERVERS,
                     CHANGEFEED_SINK_TLS_CA_CERT_FILE,
                     CHANGEFEED_SINK_TLS_CLIENT_CERT_FILE,
@@ -1177,6 +1192,10 @@ public class CockroachDBConnectorConfig extends RelationalDatabaseConnectorConfi
 
     public String getChangefeedKafkaAutoOffsetReset() {
         return config.getString(CHANGEFEED_KAFKA_AUTO_OFFSET_RESET);
+    }
+
+    public boolean isChangefeedKafkaConsumerOffsetCommitEnabled() {
+        return config.getBoolean(CHANGEFEED_KAFKA_CONSUMER_OFFSET_COMMIT_ENABLED);
     }
 
     public String getChangefeedSinkTlsCaCertFile() {

--- a/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
+++ b/src/main/java/io/debezium/connector/cockroachdb/CockroachDBStreamingChangeEventSource.java
@@ -40,6 +40,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -595,6 +596,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
             Duration pollInterval = Duration.ofMillis(config.getChangefeedPollIntervalMs());
             Metronome metronome = Metronome.sleeper(pollInterval, clock);
             int emptyPollCount = 0;
+            boolean commitOffsetsToGroup = config.isChangefeedKafkaConsumerOffsetCommitEnabled();
 
             while (context.isRunning() && running.get()) {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(config.getChangefeedKafkaPollTimeoutMs()));
@@ -612,6 +614,7 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     LOGGER.trace("Polled {} records from {} topic(s)", records.count(), topicNames.size());
                 }
 
+                Map<TopicPartition, OffsetAndMetadata> positionsToMirror = commitOffsetsToGroup ? new HashMap<>() : null;
                 for (ConsumerRecord<String, String> record : records) {
                     if (!context.isRunning()) {
                         break;
@@ -619,6 +622,10 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                     // Record the consumed position so it is persisted in the Debezium offset (flushed
                     // by Connect after the dispatched events are produced) and a restart can resume here.
                     offsetContext.setConsumerOffset(kafkaConsumerOffsetKey(record.topic(), record.partition()), record.offset());
+                    if (positionsToMirror != null) {
+                        positionsToMirror.put(new TopicPartition(record.topic(), record.partition()),
+                                new OffsetAndMetadata(record.offset() + 1));
+                    }
                     String valueJson = record.value();
                     if (valueJson != null && !valueJson.trim().isEmpty()) {
                         TableId table = resolveTableFromTopic(record.topic());
@@ -629,6 +636,17 @@ public class CockroachDBStreamingChangeEventSource implements StreamingChangeEve
                             LOGGER.warn("Cannot resolve table for topic '{}', skipping event", record.topic());
                         }
                     }
+                }
+
+                if (positionsToMirror != null && !positionsToMirror.isEmpty()) {
+                    // Observability mirror only: the connector resumes from the Debezium offsets via the
+                    // explicit seeks above, never from the group, so a failed commit must never fail the
+                    // pipeline.
+                    consumer.commitAsync(positionsToMirror, (offsets, exception) -> {
+                        if (exception != null) {
+                            LOGGER.debug("Failed to mirror consumer positions to the Kafka group: {}", exception.getMessage());
+                        }
+                    });
                 }
 
                 offsetActivityMonitorService.pulse(currentPartition, offsetContext);

--- a/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/CockroachDBConnectorConfigTest.java
@@ -591,4 +591,33 @@ public class CockroachDBConnectorConfigTest {
         assertThat(overrides.getString("max.poll.records")).isEqualTo("1000");
         assertThat(overrides.keys()).hasSize(2);
     }
+
+    @Test
+    public void shouldDefaultConsumerOffsetCommitToDisabled() {
+        Map<String, String> props = new HashMap<>();
+        props.put("database.hostname", "localhost");
+        props.put("database.port", "26257");
+        props.put("database.user", "root");
+        props.put("database.dbname", "testdb");
+        props.put("topic.prefix", "test");
+
+        CockroachDBConnectorConfig config = new CockroachDBConnectorConfig(Configuration.from(props));
+
+        assertThat(config.isChangefeedKafkaConsumerOffsetCommitEnabled()).isFalse();
+    }
+
+    @Test
+    public void shouldEnableConsumerOffsetCommitWhenConfigured() {
+        Map<String, String> props = new HashMap<>();
+        props.put("database.hostname", "localhost");
+        props.put("database.port", "26257");
+        props.put("database.user", "root");
+        props.put("database.dbname", "testdb");
+        props.put("topic.prefix", "test");
+        props.put("cockroachdb.changefeed.kafka.consumer.offset.commit.enabled", "true");
+
+        CockroachDBConnectorConfig config = new CockroachDBConnectorConfig(Configuration.from(props));
+
+        assertThat(config.isChangefeedKafkaConsumerOffsetCommitEnabled()).isTrue();
+    }
 }

--- a/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
+++ b/src/test/java/io/debezium/connector/cockroachdb/integration/CockroachDBRegressionScenariosIT.java
@@ -15,7 +15,13 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
@@ -51,6 +57,10 @@ import ch.qos.logback.core.read.ListAppender;
  * {@code kafka_sink_config} changefeed option.</li>
  * <li>DBZ-2390: generated changefeed SQL must quote a hyphenated schema and a reserved-word
  * table in both Kafka and sinkless delivery modes.</li>
+ * <li>{@link #shouldMirrorConsumerPositionsToTheKafkaGroupWhenEnabled} (debezium/dbz#2472):
+ * with {@code cockroachdb.changefeed.kafka.consumer.offset.commit.enabled} the connector
+ * mirrors its consumed positions to the Kafka consumer group so external lag tooling works;
+ * {@link #shouldNotCommitGroupOffsetsByDefault} guards that the default stays commit-free.</li>
  * </ul>
  *
  * @author Virag Tripathi
@@ -280,6 +290,81 @@ public class CockroachDBRegressionScenariosIT extends AbstractCockroachDBPipelin
                         "SELECT count(*) FROM [SHOW CHANGEFEED JOBS] WHERE status IN ('running', 'paused') AND description LIKE '%paused_events%'")) {
             rs.next();
             assertThat(rs.getInt(1)).as("No duplicate changefeed job may be created").isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void shouldMirrorConsumerPositionsToTheKafkaGroupWhenEnabled() throws Exception {
+        connection = openDatabase("offsetmirror_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS mirror_events (id INT8 PRIMARY KEY, name STRING NOT NULL)");
+            stmt.execute("UPSERT INTO mirror_events VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Carol')");
+        }
+
+        Map<String, String> config = baseConnectorConfig("offsetmirror-test", "offsetmirror_testdb", "public.mirror_events");
+        config.put("cockroachdb.changefeed.kafka.consumer.group.prefix", "offsetmirror-group");
+        config.put("cockroachdb.changefeed.kafka.consumer.offset.commit.enabled", "true");
+        startTask(config);
+
+        List<SourceRecord> records = pollForRecords(3, 45);
+        assertThat(records).as("Should receive the seed rows").hasSizeGreaterThanOrEqualTo(3);
+
+        // The mirror commit is asynchronous and only exists for external lag tooling, so poll the
+        // group offsets the way kafka-consumer-groups would until they appear.
+        Map<TopicPartition, OffsetAndMetadata> committed = new HashMap<>();
+        for (int i = 0; i < 30 && committed.isEmpty(); i++) {
+            committed = committedGroupOffsets("offsetmirror-group");
+            if (committed.isEmpty()) {
+                task.poll();
+                Thread.sleep(1000);
+            }
+        }
+
+        assertThat(committed)
+                .as("The consumer group should carry committed offsets for the intermediate topic")
+                .isNotEmpty();
+        assertThat(committed.keySet())
+                .anyMatch(tp -> tp.topic().contains("mirror_events"));
+        long mirroredPositions = committed.values().stream().mapToLong(OffsetAndMetadata::offset).sum();
+        assertThat(mirroredPositions)
+                .as("The mirrored position should cover the consumed events")
+                .isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    public void shouldNotCommitGroupOffsetsByDefault() throws Exception {
+        connection = openDatabase("offsetdefault_testdb");
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS default_events (id INT8 PRIMARY KEY, name STRING NOT NULL)");
+            stmt.execute("UPSERT INTO default_events VALUES (1, 'Alice')");
+        }
+
+        Map<String, String> config = baseConnectorConfig("offsetdefault-test", "offsetdefault_testdb", "public.default_events");
+        config.put("cockroachdb.changefeed.kafka.consumer.group.prefix", "offsetdefault-group");
+        startTask(config);
+
+        List<SourceRecord> records = pollForRecords(1, 45);
+        assertThat(records).as("Should receive the seed row").isNotEmpty();
+
+        // Give the consumer a few more poll cycles; without the option no commit may ever happen.
+        for (int i = 0; i < 3; i++) {
+            task.poll();
+            Thread.sleep(1000);
+        }
+
+        assertThat(committedGroupOffsets("offsetdefault-group"))
+                .as("Without the option the connector must never commit group offsets")
+                .isEmpty();
+    }
+
+    private Map<TopicPartition, OffsetAndMetadata> committedGroupOffsets(String groupId) throws Exception {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+                kafka.getBootstrapServers().replaceFirst("^PLAINTEXT://", ""));
+        try (Admin admin = Admin.create(props)) {
+            return admin.listConsumerGroupOffsets(groupId)
+                    .partitionsToOffsetAndMetadata()
+                    .get(30, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2472

The intermediate consumer stores its positions in the Debezium offsets and never commits to its Kafka consumer group, so kafka-consumer-groups and lag dashboards show no committed offsets for the connector and cannot track its progress. In one production case an operator's one-off console-consumer commit froze a bogus offset into the group, which then read as a stuck consumer while the pipeline was advancing normally.

Adds `cockroachdb.changefeed.kafka.consumer.offset.commit.enabled`, disabled by default. When enabled, the connector asynchronously commits the positions of each processed batch to the consumer group as an observability mirror. A failed commit is logged at debug level and never fails the pipeline. Restarts always resume from the Debezium offsets via the existing explicit seeks, so the option has no effect on delivery semantics.

Verification: unit and integration suites green, including a new integration scenario that asserts the group carries committed offsets covering the consumed events when the option is set, and a companion scenario that asserts the default stays commit-free. Full crdb-to-crdb example run from this branch shows kafka-consumer-groups reporting current offset and lag zero for all intermediate topics, and the restart resume step confirms replay-free resume with the option enabled. Cloud sanity run against CockroachDB Cloud green. Docs PR for the property row follows in debezium/debezium.